### PR TITLE
Eswe 397

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -10,6 +10,7 @@
 # Suppression for snakeyaml 1.30 vulnerability as bundled with application insights so can't be upgraded easily
 #   Can be suppressed as we we don't parse untrusted yaml
 CVE-2022-25857
-# Suppression for snakeyaml 1.31 vulnerability as no current upgrade path available
+CVE-2022-38751
+# Suppression for snakeyaml 1.31 vulnerability as not fixed yet
 #   Can be suppressed as we we don't parse untrusted yaml
 CVE-2022-38752

--- a/.trivyignore
+++ b/.trivyignore
@@ -13,4 +13,5 @@ CVE-2022-25857
 CVE-2022-38751
 # Suppression for snakeyaml 1.31 vulnerability as not fixed yet
 #   Can be suppressed as we we don't parse untrusted yaml
+CVE-2022-38751
 CVE-2022-38752

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.5.0"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.5.1"
   kotlin("plugin.spring") version "1.7.10"
 }
 


### PR DESCRIPTION
There is a new snakeyml vulnerability found by CI - this is an update to use the 4.5.2 of ops grade parent and an additional trivy ignore