### PR TITLE
ESWE-451 - Switch to Ingress controller v1.2

### DIFF
--- a/helm_deploy/hmpps-education-employment-api/Chart.yaml
+++ b/helm_deploy/hmpps-education-employment-api/Chart.yaml
@@ -8,5 +8,5 @@ dependencies:
     version: 2.1.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: 2.1.0
+    version: 1.1.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/helm_deploy/hmpps-education-employment-api/Chart.yaml
+++ b/helm_deploy/hmpps-education-employment-api/Chart.yaml
@@ -5,8 +5,8 @@ name: hmpps-education-employment-api
 version: 0.2.0
 dependencies:
   - name: generic-service
-    version: 1.2.1
+    version: 2.1.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: 0.3.0
+    version: 2.1.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/helm_deploy/hmpps-education-employment-api/values.yaml
+++ b/helm_deploy/hmpps-education-employment-api/values.yaml
@@ -10,6 +10,7 @@ generic-service:
     port: 8080
 
   ingress:
+    v1_2_enabled: true
     enabled: true
     host: app-hostname.local    # override per environment
     tlsSecretName: hmpps-education-employment-api-cert

--- a/helm_deploy/hmpps-education-employment-api/values.yaml
+++ b/helm_deploy/hmpps-education-employment-api/values.yaml
@@ -11,6 +11,7 @@ generic-service:
 
   ingress:
     v1_2_enabled: true
+    v0_47_enabled: false
     enabled: true
     host: app-hostname.local    # override per environment
     tlsSecretName: hmpps-education-employment-api-cert


### PR DESCRIPTION
## What does this pull request do?
🔧 Enable ingress controller v1.2
🔧 Disable ingress controller v0.47
🔧 Upgrade charts

## What is the intent behind these changes?
Cloud Platform will be carrying out the Kubernetes 1.22 upgrade from Tuesday 15th November.
Before this time, we must switch to Ingress controller v1.2 and disable v0.47.

See: https://github.com/ministryofjustice/hmpps-helm-charts/releases/tag/generic-service-1.5.0

Signed-off-by: theDustRoom <paul.massey@digital.justice.gov.uk>