### PR TITLE
Upgrade helm chart

### DIFF
--- a/helm_deploy/hmpps-education-employment-api/Chart.yaml
+++ b/helm_deploy/hmpps-education-employment-api/Chart.yaml
@@ -5,8 +5,8 @@ name: hmpps-education-employment-api
 version: 1.0.0
 dependencies:
   - name: generic-service
-    version: 2.3.0
+    version: 2.6.5
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: 1.2.4
+    version: 1.3.3
     repository: https://ministryofjustice.github.io/hmpps-helm-charts


### PR DESCRIPTION
Action Required from Service Teams - Kubernetes 1.25 Upgrade - Removing deprecated APIs