### PR TITLE
Migrating project to use groups in allowlist

### DIFF
--- a/helm_deploy/hmpps-education-employment-api/Chart.yaml
+++ b/helm_deploy/hmpps-education-employment-api/Chart.yaml
@@ -5,8 +5,8 @@ name: hmpps-education-employment-api
 version: 1.0.0
 dependencies:
   - name: generic-service
-    version: 2.3.0
+    version: 2.6.5
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: 1.2.4
+    version: 1.3.3
     repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/helm_deploy/hmpps-education-employment-api/Chart.yaml
+++ b/helm_deploy/hmpps-education-employment-api/Chart.yaml
@@ -5,7 +5,7 @@ name: hmpps-education-employment-api
 version: 1.0.0
 dependencies:
   - name: generic-service
-    version: 2.6.5
+    version: "2.8"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: 1.3.3

--- a/helm_deploy/hmpps-education-employment-api/values.yaml
+++ b/helm_deploy/hmpps-education-employment-api/values.yaml
@@ -1,4 +1,3 @@
----
 generic-service:
   nameOverride: hmpps-education-employment-api
 
@@ -6,14 +5,14 @@ generic-service:
 
   image:
     repository: quay.io/hmpps/hmpps-education-employment-api
-    tag: app_version    # override at deployment time
+    tag: app_version # override at deployment time
     port: 8080
 
   ingress:
     v1_2_enabled: true
     v0_47_enabled: false
     enabled: true
-    host: app-hostname.local    # override per environment
+    host: app-hostname.local # override per environment
     tlsSecretName: hmpps-education-employment-api-cert
     contextColour: green
 
@@ -40,14 +39,8 @@ generic-service:
       DATABASE_ENDPOINT: "rds_instance_endpoint"
 
   allowlist:
-    office: "217.33.148.210/32"
-    health-kick: "35.177.252.195/32"
-    petty-france-wifi: "213.121.161.112/28"
-    global-protect: "35.176.93.186/32"
-    mojvpn: "81.134.202.29/32"
-    cloudplatform-live-1: "35.178.209.113/32"
-    cloudplatform-live-2: "3.8.51.207/32"
-    cloudplatform-live-3: "35.177.252.54/32"
+    groups:
+      - internal
 
 generic-prometheus-alerts:
   targetApplication: hmpps-education-employment-api


### PR DESCRIPTION
This PR migrates the project to use groups of IPs in their allowlist.

By referring to groups to IP addresses, we can centralize the definition of groups of ip addresses.
If these lists require changing in the future, we can change the definition once and future deploys across all services will automatically include these new IPs.

1 allowlist(s) have been detected that can be migrated.



## Allowlist: helm_deploy/hmpps-education-employment-api/values.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: `internal`
- The size of the allowlist defined in this file will change: `8 => 0 (8 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:

  Merging this PR should not result in any additional IP addresses being added to the allowlist.

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:


- health-kick
  
