### PR TITLE
ESWE-1046 upgrade dependencies for tomcat vulnerability

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  hmpps: ministryofjustice/hmpps@9
+  hmpps: ministryofjustice/hmpps@10
 
 parameters:
   alerts-slack-channel:

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 .idea/
 .gradle/
+.kotlin/
 build/
 
 # CMake

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM --platform=$BUILDPLATFORM eclipse-temurin:21-jre-jammy AS builder
+FROM --platform=$BUILDPLATFORM eclipse-temurin:21-jdk-jammy AS builder
 
 ARG BUILD_NUMBER
-ENV BUILD_NUMBER ${BUILD_NUMBER:-1_0_0}
+ENV BUILD_NUMBER=${BUILD_NUMBER:-1_0_0}
 
 WORKDIR /app
 ADD . .
@@ -15,7 +15,7 @@ FROM eclipse-temurin:21-jre-jammy
 LABEL maintainer="HMPPS Digital Studio <info@digital.justice.gov.uk>"
 
 ARG BUILD_NUMBER
-ENV BUILD_NUMBER ${BUILD_NUMBER:-1_0_0}
+ENV BUILD_NUMBER=${BUILD_NUMBER:-1_0_0}
 
 RUN apt-get update && \
     apt-get -y upgrade && \

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "6.0.0"
-  kotlin("plugin.spring") version "2.0.0"
-  kotlin("plugin.jpa") version "2.0.0"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "6.0.4"
+  kotlin("plugin.spring") version "2.0.20"
+  kotlin("plugin.jpa") version "2.0.20"
   id("jacoco")
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,4 +6,3 @@
 #
 # To stop the dps-gradle-spring-boot project from overwriting any project specific customisations here, remove the
 # warning at the top of this file.
-kotlin.incremental.useClasspathSnapshot=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/helm_deploy/hmpps-education-employment-api/Chart.yaml
+++ b/helm_deploy/hmpps-education-employment-api/Chart.yaml
@@ -2,10 +2,10 @@ apiVersion: v2
 appVersion: '1.0'
 description: A Helm chart for Kubernetes
 name: hmpps-education-employment-api
-version: 0.1.1
+version: 0.1.2
 dependencies:
   - name: generic-service
-    version: "3.3"
+    version: "3.4"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: "1.8"


### PR DESCRIPTION
Upgrade Tomcat (and Spring Boot) for Tomcat Vulnerability
--------------
1) Upgrade HMPPS Gradle Spring Boot plug-in to 6.0.4, including:
    Upgrade Spring Boot to 3.3.3 (from 3.3.0)
    Upgrade Tomcat to 10.1.28 (from 10.1.24)
2) Upgrade Kotlin to 2.0.20 (from 2.0.0)
3) Upgrade Gradle to 8.10 (from 8.7)
--------------
4) Fixed 2 warnings at Dockerfile