### PR TITLE
[ESWE-1075] Upgrade Spring Boot and dependencies for fixing vulnerabilities

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "6.0.4"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "6.0.6"
   kotlin("plugin.spring") version "2.0.20"
   kotlin("plugin.jpa") version "2.0.20"
   id("jacoco")
@@ -9,7 +9,7 @@ dependencies {
   implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:2.1.1")
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
-  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0")
+  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0")
   implementation("com.fasterxml.jackson.core:jackson-databind")
   implementation("io.jsonwebtoken:jjwt-impl:0.12.5")
   implementation("io.jsonwebtoken:jjwt-jackson:0.12.5")


### PR DESCRIPTION
CVE-2024-38816 : upgrade Spring Boot
CVE-2024-45801 : upgrade dependencies (for OpenAPI)

**Spring Boot** 3.3.4 (framework 6.1.13) has addressed this vulnerability (CVE-2024-38816)

upgrade these dependencies (CVE-2024-45801)
* springdoc-**openapi**-starter-webmvc-ui to 2.6.0 (from 2.3.0),
  including these:
  * **swagger-ui** to 5.17.14 (from 5.10.3)
  * **dompurify** to 3.1.4 (from 3.0.6)