### PR TITLE
[ESWE-1079] patching commons-compress (CVE-2024-26308, CVE-2024-25710)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,7 +45,9 @@ testing {
         runtimeOnly("org.flywaydb:flyway-database-postgresql")
         implementation("com.zaxxer:HikariCP:5.1.0")
         implementation("com.h2database:h2")
-        implementation("org.testcontainers:postgresql")
+        implementation("org.testcontainers:postgresql") {
+          implementation("org.apache.commons:commons-compress:1.27.1")
+        }
       }
 
       targets {


### PR DESCRIPTION
fix CVE-2024-26308, CVE-2024-25710 of commons-compress (used in testcontainers postgresql)