### PR TITLE
[ESWE-1109] Upgrade Spring Boot Upgrade framework and dependencies for resolving vulnerabilities.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "6.0.6"
-  kotlin("plugin.spring") version "2.0.20"
-  kotlin("plugin.jpa") version "2.0.20"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "6.0.8"
+  kotlin("plugin.spring") version "2.0.21"
+  kotlin("plugin.jpa") version "2.0.21"
   id("jacoco")
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/helm_deploy/hmpps-education-employment-api/Chart.yaml
+++ b/helm_deploy/hmpps-education-employment-api/Chart.yaml
@@ -5,8 +5,8 @@ name: hmpps-education-employment-api
 version: 0.1.2
 dependencies:
   - name: generic-service
-    version: "3.4"
+    version: "3.6"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: "1.8"
+    version: "1.10"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts


### PR DESCRIPTION
Upgrade framework and dependencies for resolving vulnerabilities.

- upgrade Spring Boot to `3.3.5` (and Spring Framework `6.1.14`); (was
  `3.3.4` and `6.1.13`)
- upgrade Kotlin to `2.0.21` (was `2.0.20`)