### PR TITLE
[ESWE-1140] Upgrade dependencies for resolving vulnerabilities.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,11 @@ plugins {
 }
 
 dependencies {
-  implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:2.1.1")
+  implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:5.1.1") {
+    implementation("io.netty:netty-common:4.1.115.Final")
+    implementation("org.apache.commons:commons-compress:1.27.1")
+    testImplementation("org.xmlunit:xmlunit-core:2.10.0")
+  }
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
   implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0")
@@ -36,7 +40,9 @@ testing {
       dependencies {
         testType.set(TestSuiteType.INTEGRATION_TEST)
         kotlin.target.compilations { named("integrationTest") { associateWith(getByName("main")) } }
-        implementation("org.springframework.boot:spring-boot-starter-test")
+        implementation("org.springframework.boot:spring-boot-starter-test") {
+          implementation("org.xmlunit:xmlunit-core:2.10.0")
+        }
         implementation("org.springframework.security:spring-security-test")
         implementation("io.jsonwebtoken:jjwt-impl:0.12.5")
         implementation("io.jsonwebtoken:jjwt-jackson:0.12.5")


### PR DESCRIPTION
- upgrade `netty-common` to `4.1.115.Final` (was `4.1.114.Final`
- upgrade `hmpps-sqs-spring-boot-starter` to `5.1.1` (was `2.1.1`)
- explicitly specify versions of some transitive dependencies (`commons-compress`, `xmlunit-core`)