### PR TITLE
[ESWE-1199] Upgrade dependencies for resolving vulnerabilities.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,19 +1,19 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "6.0.8"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "6.1.2"
   kotlin("plugin.spring") version "2.0.21"
   kotlin("plugin.jpa") version "2.0.21"
   id("jacoco")
 }
 
+ext["logback.version"] = "1.5.15"
+
 dependencies {
   implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:5.1.1") {
-    implementation("io.netty:netty-common:4.1.115.Final")
     implementation("org.apache.commons:commons-compress:1.27.1")
-    testImplementation("org.xmlunit:xmlunit-core:2.10.0")
   }
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
-  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0")
+  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0")
   implementation("com.fasterxml.jackson.core:jackson-databind")
   implementation("io.jsonwebtoken:jjwt-impl:0.12.5")
   implementation("io.jsonwebtoken:jjwt-jackson:0.12.5")
@@ -40,9 +40,7 @@ testing {
       dependencies {
         testType.set(TestSuiteType.INTEGRATION_TEST)
         kotlin.target.compilations { named("integrationTest") { associateWith(getByName("main")) } }
-        implementation("org.springframework.boot:spring-boot-starter-test") {
-          implementation("org.xmlunit:xmlunit-core:2.10.0")
-        }
+        implementation("org.springframework.boot:spring-boot-starter-test")
         implementation("org.springframework.security:spring-security-test")
         implementation("io.jsonwebtoken:jjwt-impl:0.12.5")
         implementation("io.jsonwebtoken:jjwt-jackson:0.12.5")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/helm_deploy/hmpps-education-employment-api/Chart.yaml
+++ b/helm_deploy/hmpps-education-employment-api/Chart.yaml
@@ -5,8 +5,8 @@ name: hmpps-education-employment-api
 version: 0.1.2
 dependencies:
   - name: generic-service
-    version: "3.6"
+    version: "3.7"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: "1.10"
+    version: "1.11"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts


### PR DESCRIPTION
Upgrade dependencies

- HMPPS Spring Boot plugin `6.1.2` (was `6.0.8`)
  - Spring Boot `3.4.1` (was `3.3.5`)
  - embed tomcat `10.1.34` (was `10.1.31`)
  - logback `1.5.15` (was `1.5.11`)
- and more