### PR TITLE
[ESWE-1270] Audit changes, refactor tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,11 @@ jobs:
       postgres_tag: "16.2"
       postgres_username: "education-employment"
       postgres_password: "education-employment"
+    environment:
+      DATABASE_ENDPOINT: localhost:5432
+      DATABASE_NAME: education-employment
+      DATABASE_USERNAME: education-employment
+      DATABASE_PASSWORD: education-employment
     steps:
       - checkout
       - restore_cache:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,10 +33,12 @@ dependencies {
 
 testing {
   suites {
+    @Suppress("UnstableApiUsage")
     val test by getting(JvmTestSuite::class) {
       useJUnitJupiter()
     }
 
+    @Suppress("UnstableApiUsage")
     val integrationTest by registering(JvmTestSuite::class) {
       dependencies {
         testType.set(TestSuiteType.INTEGRATION_TEST)
@@ -49,10 +51,10 @@ testing {
         implementation("com.microsoft.azure:applicationinsights-logging-logback")
         runtimeOnly("org.flywaydb:flyway-database-postgresql")
         implementation("com.zaxxer:HikariCP:5.1.0")
-        implementation("com.h2database:h2")
         implementation("org.testcontainers:postgresql") {
           implementation("org.apache.commons:commons-compress:1.27.1")
         }
+        implementation("org.mockito.kotlin:mockito-kotlin:5.4.0")
       }
 
       targets {

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/audit/domain/AuditObjects.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/audit/domain/AuditObjects.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.educationemployment.api.audit.domain
+
+import java.time.Instant
+import java.time.ZoneId
+
+object AuditObjects {
+  val username = "auser_gen"
+  val displayName = "John Doe"
+  val system = "system"
+
+  val defaultAuditor = username
+
+  val defaultAuditTime = Instant.parse("2025-01-01T00:00:00.00Z")
+  val defaultTimezoneId = ZoneId.of("Z")
+  val defaultAuditLocalTime = defaultAuditTime.atZone(defaultTimezoneId).toLocalDateTime()
+}

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/integration/IntegrationTestBase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/integration/IntegrationTestBase.kt
@@ -10,7 +10,6 @@ import org.springframework.test.context.DynamicPropertySource
 import uk.gov.justice.digital.hmpps.educationemployment.api.HmppsEducationEmploymentApi
 import uk.gov.justice.digital.hmpps.educationemployment.api.integration.helpers.JwtAuthHelper
 import uk.gov.justice.digital.hmpps.educationemployment.api.integration.testcontainers.PostgresContainer
-import uk.gov.justice.digital.hmpps.educationemployment.api.repository.ReadinessProfileRepository
 
 @SpringBootTest(
   webEnvironment = RANDOM_PORT,
@@ -43,9 +42,6 @@ abstract class IntegrationTestBase internal constructor() {
 
   @Autowired
   lateinit var restTemplate: TestRestTemplate
-
-  @Autowired
-  lateinit var readinessProfileRepository: ReadinessProfileRepository
 
   @Autowired
   lateinit var jwtAuthHelper: JwtAuthHelper

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/integration/config/TestConfig.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/integration/config/TestConfig.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.educationemployment.api.integration
+package uk.gov.justice.digital.hmpps.educationemployment.api.integration.config
 
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/integration/resource/ReadinessProfileIntTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/integration/resource/ReadinessProfileIntTest.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpEntity
@@ -14,11 +15,10 @@ import uk.gov.justice.digital.hmpps.educationemployment.api.config.ErrorResponse
 import uk.gov.justice.digital.hmpps.educationemployment.api.data.NoteRequestDTO
 import uk.gov.justice.digital.hmpps.educationemployment.api.data.ReadinessProfileDTO
 import uk.gov.justice.digital.hmpps.educationemployment.api.data.ReadinessProfileRequestDTO
-import uk.gov.justice.digital.hmpps.educationemployment.api.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.educationemployment.api.integration.shared.infrastructure.ApplicationTestCase
 import uk.gov.justice.digital.hmpps.educationemployment.api.integration.util.TestData
 
-@Suppress("NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS")
-class ReadinessProfileIntTest : IntegrationTestBase() {
+class ReadinessProfileIntTest : ApplicationTestCase() {
 
   @Autowired
   lateinit var objectMapper: ObjectMapper
@@ -32,9 +32,9 @@ class ReadinessProfileIntTest : IntegrationTestBase() {
   fun `Get the exception for profile for a unknown offender`() {
     val result = restTemplate.exchange("/readiness-profiles/A1234AB", HttpMethod.GET, HttpEntity<HttpHeaders>(setAuthorisation(roles = listOf("ROLE_WORK_READINESS_EDIT", "ROLE_WORK_READINESS_VIEW"))), ErrorResponse::class.java)
     assertThat(result).isNotNull
-    val erroResponse = result.body
-    assert(erroResponse.status.equals(HttpStatus.BAD_REQUEST.value()))
-    assert(erroResponse.userMessage.equals("Readiness profile does not exist for offender A1234AB"))
+    val errorResponse = result.body.also { assertNotNull(it) }!!
+    assert(errorResponse.status.equals(HttpStatus.BAD_REQUEST.value()))
+    assert(errorResponse.userMessage.equals("Readiness profile does not exist for offender A1234AB"))
   }
 
   @Test
@@ -82,9 +82,9 @@ class ReadinessProfileIntTest : IntegrationTestBase() {
     restTemplate.exchange("/readiness-profiles/A1234AE", HttpMethod.POST, HttpEntity<ReadinessProfileRequestDTO>(actualReadinessProfileRequestDTO, setAuthorisation(roles = listOf("ROLE_WORK_READINESS_EDIT", "ROLE_WORK_READINESS_VIEW"))), ReadinessProfileDTO::class.java)
 
     val result = restTemplate.exchange("/readiness-profiles/A1234AE/notes/DISCLOSURE_LETTER", HttpMethod.GET, HttpEntity<HttpHeaders>(setAuthorisation("lest", roles = listOf("ROLE_WORK_READINESS_VIEW"))), List::class.java)
-    assert(result != null)
+      .also { assertNotNull(it) }!!
     assert(result.statusCode.is2xxSuccessful)
-    assert(result.body.isEmpty())
+    assert(result.body.isNullOrEmpty())
   }
 
   @Test
@@ -101,7 +101,7 @@ class ReadinessProfileIntTest : IntegrationTestBase() {
     val result = restTemplate.exchange("/readiness-profiles/A1234AT/notes/DISCLOSURE_LETTER", HttpMethod.POST, HttpEntity<NoteRequestDTO>(noteRequestDTO, setAuthorisation("lest", roles = listOf("ROLE_WORK_READINESS_EDIT"))), List::class.java)
     assertThat(result).isNotNull
     assert(result.statusCode.is2xxSuccessful)
-    assert(result.body.size > 0)
+    assertThat(result.body).isNotEmpty
   }
 
   @Test
@@ -118,11 +118,11 @@ class ReadinessProfileIntTest : IntegrationTestBase() {
     val result = restTemplate.exchange("/readiness-profiles/A1234AZ/notes/DISCLOSURE_LETTER", HttpMethod.POST, HttpEntity<NoteRequestDTO>(noteRequestDTO, setAuthorisation("lest", roles = listOf("ROLE_WORK_READINESS_EDIT"))), List::class.java)
     assertThat(result).isNotNull
     assert(result.statusCode.is2xxSuccessful)
-    assert(result.body.size > 0)
+    assertThat(result.body).isNotEmpty
 
     val noteList = restTemplate.exchange("/readiness-profiles/A1234AZ/notes/DISCLOSURE_LETTER", HttpMethod.GET, HttpEntity<HttpHeaders>(setAuthorisation("lest", roles = listOf("ROLE_WORK_READINESS_EDIT"))), List::class.java)
     assertThat(result).isNotNull
     assert(result.statusCode.is2xxSuccessful)
-    assert(result.body.size > 0)
+    assertThat(result.body).isNotEmpty
   }
 }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/integration/resource/ReadinessProfileTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/integration/resource/ReadinessProfileTestCase.kt
@@ -14,9 +14,9 @@ import uk.gov.justice.digital.hmpps.educationemployment.api.data.NoteRequestDTO
 import uk.gov.justice.digital.hmpps.educationemployment.api.data.ReadinessProfileDTO
 import uk.gov.justice.digital.hmpps.educationemployment.api.data.ReadinessProfileRequestDTO
 import uk.gov.justice.digital.hmpps.educationemployment.api.data.jsonprofile.ActionTodo
-import uk.gov.justice.digital.hmpps.educationemployment.api.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.educationemployment.api.integration.shared.infrastructure.ApplicationTestCase
 
-abstract class ReadinessProfileTestCase : IntegrationTestBase() {
+abstract class ReadinessProfileTestCase : ApplicationTestCase() {
   @Autowired
   protected lateinit var objectMapper: ObjectMapper
 

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/integration/resource/SARReadinessProfileGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/integration/resource/SARReadinessProfileGetShould.kt
@@ -11,8 +11,6 @@ import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.educationemployment.api.data.ReadinessProfileDTO
 import uk.gov.justice.digital.hmpps.educationemployment.api.data.jsonprofile.ActionTodo
 import uk.gov.justice.digital.hmpps.educationemployment.api.data.jsonprofile.Profile
-import uk.gov.justice.digital.hmpps.educationemployment.api.integration.resource.SARTestData.anotherPrisonNumber
-import uk.gov.justice.digital.hmpps.educationemployment.api.integration.resource.SARTestData.knownPrisonNumber
 import uk.gov.justice.digital.hmpps.educationemployment.api.integration.resource.SARTestData.knownnCaseReferenceNumber
 import uk.gov.justice.digital.hmpps.educationemployment.api.integration.resource.SARTestData.makeProfileRequestOfAnotherPrisonNumber
 import uk.gov.justice.digital.hmpps.educationemployment.api.integration.resource.SARTestData.makeProfileRequestWithSupportAccepted
@@ -21,8 +19,9 @@ import uk.gov.justice.digital.hmpps.educationemployment.api.integration.resource
 import uk.gov.justice.digital.hmpps.educationemployment.api.integration.resource.SARTestData.profileJsonWithSupportAcceptedHistory
 import uk.gov.justice.digital.hmpps.educationemployment.api.integration.resource.SARTestData.profileOfAnotherPrisonNumber
 import uk.gov.justice.digital.hmpps.educationemployment.api.integration.resource.SARTestData.profileRequestOfKnownPrisonNumber
-import uk.gov.justice.digital.hmpps.educationemployment.api.integration.resource.SARTestData.unknownPrisonNumber
-import java.time.LocalDate
+import uk.gov.justice.digital.hmpps.educationemployment.api.readinessprofile.domain.ProfileObjects.anotherPrisonNumber
+import uk.gov.justice.digital.hmpps.educationemployment.api.readinessprofile.domain.ProfileObjects.knownPrisonNumber
+import uk.gov.justice.digital.hmpps.educationemployment.api.readinessprofile.domain.ProfileObjects.unknownPrisonNumber
 
 class SARReadinessProfileGetShould : SARReadinessProfileTestCase() {
   @AfterEach
@@ -158,7 +157,7 @@ class SARReadinessProfileGetShould : SARReadinessProfileTestCase() {
     @Nested
     @DisplayName("And period filter (fromDate, toDate) has been set")
     inner class AndPeriodFilterHasBeenSet {
-      private val today = LocalDate.now()
+      private val today = defaultCurrentTimeLocal.toLocalDate()
       private val tomorrow = today.plusDays(1)
       private val yesterday = today.minusDays(1)
 

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/integration/resource/SARTestData.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/integration/resource/SARTestData.kt
@@ -4,33 +4,26 @@ import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.JsonNode
 import uk.gov.justice.digital.hmpps.educationemployment.api.config.CapturedSpringConfigValues
 import uk.gov.justice.digital.hmpps.educationemployment.api.data.ReadinessProfileRequestDTO
-import uk.gov.justice.digital.hmpps.educationemployment.api.integration.util.TestData
-import java.io.File
+import uk.gov.justice.digital.hmpps.educationemployment.api.readinessprofile.domain.ProfileObjects.createProfileJsonRequest
+import uk.gov.justice.digital.hmpps.educationemployment.api.readinessprofile.domain.ProfileObjects.createProfileJsonRequestWithSupportAccepted
+import uk.gov.justice.digital.hmpps.educationemployment.api.readinessprofile.domain.ProfileObjects.createProfileJsonRequestWithSupportDeclined
 
 object SARTestData {
   private val objectMapperSAR = CapturedSpringConfigValues.objectMapperSAR
   private val objectMapper = CapturedSpringConfigValues.objectMapper
 
-  val knownPrisonNumber = "A1234BB"
-  val profileRequestOfKnownPrisonNumber = makeProfileRequestDTO(TestData.createProfileJsonRequest)
+  val knownnCaseReferenceNumber = "X08769"
+
+  val profileRequestOfKnownPrisonNumber = makeProfileRequestDTO(createProfileJsonRequest)
   val profileJsonOfKnownPrisonNumber = objectMapperSAR.valueToTree<JsonNode>(profileRequestOfKnownPrisonNumber).get("profileData")
 
-  val createProfileJsonRequestWithSupportDeclined =
-    File("src/test/resources/CreateProfileDeclinedHistories.json").inputStream().readBytes().toString(Charsets.UTF_8)
-  val anotherPrisonNumber = "K9876BC"
   val profileOfAnotherPrisonNumber =
     makeProfileRequestDTO(createProfileJsonRequestWithSupportDeclined, cleanHistory = false).profileData
   val profileJsonOfAnotherPrisonNumber = objectMapperSAR.valueToTree<JsonNode>(profileOfAnotherPrisonNumber)
 
-  val createProfileJsonRequestWithSupportAccepted =
-    File("src/test/resources/CreateProfileAcceptedHistories.json").inputStream().readBytes().toString(Charsets.UTF_8)
   val profileWithSupportAcceptedHistory =
     makeProfileRequestDTO(createProfileJsonRequestWithSupportAccepted, cleanHistory = false).profileData
   val profileJsonWithSupportAcceptedHistory = objectMapperSAR.valueToTree<JsonNode>(profileWithSupportAcceptedHistory)
-
-  val unknownPrisonNumber = "A1234BD"
-
-  val knownnCaseReferenceNumber = "X08769"
 
   fun makeProfileRequestOfAnotherPrisonNumber() = makeProfileRequestDTO(createProfileJsonRequestWithSupportDeclined).apply {
     profileData.supportDeclined!!.let {

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/integration/shared/infrastructure/ApplicationTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/integration/shared/infrastructure/ApplicationTestCase.kt
@@ -1,0 +1,49 @@
+package uk.gov.justice.digital.hmpps.educationemployment.api.integration.shared.infrastructure
+
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestInstance
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.auditing.AuditingHandler
+import org.springframework.data.auditing.DateTimeProvider
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
+import uk.gov.justice.digital.hmpps.educationemployment.api.audit.domain.AuditObjects
+import uk.gov.justice.digital.hmpps.educationemployment.api.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.educationemployment.api.repository.ReadinessProfileRepository
+import uk.gov.justice.digital.hmpps.educationemployment.api.shared.application.DefaultTimeProvider
+import java.time.Instant
+import java.time.LocalDateTime
+import java.util.*
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+abstract class ApplicationTestCase : IntegrationTestBase() {
+  @MockitoBean
+  protected lateinit var dateTimeProvider: DateTimeProvider
+
+  @MockitoSpyBean
+  protected lateinit var timeProvider: DefaultTimeProvider
+
+  @MockitoSpyBean
+  protected lateinit var auditingHandler: AuditingHandler
+
+  @Autowired
+  lateinit var readinessProfileRepository: ReadinessProfileRepository
+
+  val defaultTimezoneId = AuditObjects.defaultTimezoneId
+  val defaultCurrentTime: Instant = AuditObjects.defaultAuditTime
+  val defaultCurrentTimeLocal: LocalDateTime get() = defaultCurrentTime.atZone(defaultTimezoneId).toLocalDateTime()
+
+  @BeforeAll
+  internal fun beforeAll() {
+    auditingHandler.setDateTimeProvider(dateTimeProvider)
+  }
+
+  @BeforeEach
+  internal fun setup() {
+    whenever(dateTimeProvider.now).thenReturn(Optional.of(defaultCurrentTime))
+    whenever(timeProvider.timezoneId).thenReturn(defaultTimezoneId)
+    whenever(timeProvider.now()).thenReturn(defaultCurrentTimeLocal)
+  }
+}

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/integration/util/TestData.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/integration/util/TestData.kt
@@ -20,15 +20,15 @@ import uk.gov.justice.digital.hmpps.educationemployment.api.data.jsonprofile.Wor
 import uk.gov.justice.digital.hmpps.educationemployment.api.data.jsonprofile.WorkInterests
 import uk.gov.justice.digital.hmpps.educationemployment.api.data.jsonprofile.WorkTypesOfInterest
 import uk.gov.justice.digital.hmpps.educationemployment.api.entity.ReadinessProfile
+import uk.gov.justice.digital.hmpps.educationemployment.api.readinessprofile.domain.ProfileObjects
 import uk.gov.justice.digital.hmpps.educationemployment.api.service.ProfileService
-import java.io.File
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
 
 class TestData {
   companion object {
-    val createProfileJsonRequest = File("src/test/resources/CreateProfile_correct.json").inputStream().readBytes().toString(Charsets.UTF_8)
+    val createProfileJsonRequest = ProfileObjects.createProfileJsonRequest
     val noteString: String = "Mary had another little lamb"
     private lateinit var profileService: ProfileService
 

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/readinessprofile/domain/ProfileObjects.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/readinessprofile/domain/ProfileObjects.kt
@@ -1,0 +1,44 @@
+package uk.gov.justice.digital.hmpps.educationemployment.api.readinessprofile.domain
+
+import uk.gov.justice.digital.hmpps.educationemployment.api.audit.domain.AuditObjects.defaultAuditLocalTime
+import uk.gov.justice.digital.hmpps.educationemployment.api.audit.domain.AuditObjects.defaultAuditor
+import uk.gov.justice.digital.hmpps.educationemployment.api.config.CapturedSpringConfigValues
+import uk.gov.justice.digital.hmpps.educationemployment.api.entity.ReadinessProfile
+import java.io.FileNotFoundException
+
+object ProfileObjects {
+  private val objectMapper = CapturedSpringConfigValues.objectMapper
+
+  val knownPrisonNumber = "A1234BB"
+  val anotherPrisonNumber = "K9876BC"
+  val unknownPrisonNumber = "A1234BD"
+
+  val createProfileJsonRequest = readJsonProfile("CreateProfile_correct.json")
+  val createProfileJsonRequestWithSupportDeclined = readJsonProfile("CreateProfileDeclinedHistories.json")
+  val createProfileJsonRequestWithSupportAccepted = readJsonProfile("CreateProfileAcceptedHistories.json")
+
+  val profileJsonSample = readJsonProfile("sampleprofile.json")
+  val profileJsonSample2 = readJsonProfile("sample2.json")
+  val profileJsonSampleReadinessProfile = readJsonProfile("sampleReadinessprofile.json")
+
+  val profileOfKnownPrisoner = makeProfile(knownPrisonNumber, 111111, profileJsonSample)
+  val profileOfAnotherPrisoner = makeProfile(anotherPrisonNumber, 222222, profileJsonSample2)
+
+  private fun readJsonProfile(fileName: String) = readTextFromResource("jsonprofile/$fileName")
+
+  private fun readTextFromResource(filePath: String) = this.javaClass.classLoader.getResource(filePath)?.readText()
+    ?: run { throw FileNotFoundException("$filePath not found") }
+
+  private fun makeProfile(prisonNumber: String, bookingId: Long, profileData: String, notesData: String? = null) = ReadinessProfile(
+    offenderId = prisonNumber,
+    bookingId = bookingId,
+    createdBy = defaultAuditor,
+    createdDateTime = defaultAuditLocalTime,
+    modifiedBy = defaultAuditor,
+    modifiedDateTime = defaultAuditLocalTime,
+    schemaVersion = "1.0",
+    profileData = objectMapper.readTree(profileData),
+    notesData = objectMapper.readTree(notesData ?: "[]"),
+    new = true,
+  )
+}

--- a/src/integrationTest/resources/application-integration-test.yml
+++ b/src/integrationTest/resources/application-integration-test.yml
@@ -21,22 +21,13 @@ spring:
       ddl-auto: none
 
   datasource:
-    url: 'jdbc:postgresql://localhost:5432/education-employment?sslmode=prefer'
-    username: education-employment
-    password: education-employment
-    hikari:
-      pool-name: Hmpps-Education-Employment
-      connectionTimeout: 1000
-      validationTimeout: 500
+    url: 'jdbc:postgresql://${DATABASE_ENDPOINT}/${DATABASE_NAME}?sslmode=disable&autosave=conservative'
 
   flyway:
     initOnMigrate: true
     baselineOnMigrate: true
     validateMigrationNaming: false
     enabled: true
-    url: 'jdbc:postgresql://localhost:5432/education-employment?sslmode=prefer'
-    user: education-employment
-    password: education-employment
 
 
 

--- a/src/integrationTest/resources/jsonprofile/CreateProfileAcceptedHistories.json
+++ b/src/integrationTest/resources/jsonprofile/CreateProfileAcceptedHistories.json
@@ -1,0 +1,798 @@
+{
+  "bookingId": "135791",
+  "profileData": {
+    "status": "SUPPORT_NEEDED",
+    "statusChange": false,
+    "statusChangeDate": null,
+    "prisonName": "prison2",
+    "statusChangeType": "NEW",
+    "supportDeclined_history": [],
+    "supportAccepted_history": [
+      {
+        "modifiedBy": "GDUTTON_GEN",
+        "workImpacts": {
+          "modifiedBy": "GDUTTON_GEN",
+          "modifiedDateTime": [
+            2023,
+            2,
+            15,
+            15,
+            25,
+            34,
+            910000000
+          ],
+          "abilityToWorkImpactedBy": [
+            "EDUCATION_ENROLLMENT"
+          ],
+          "ableToManageDependencies": true,
+          "ableToManageMentalHealth": false,
+          "caringResponsibilitiesFullTime": false
+        },
+        "workInterests": {
+          "modifiedBy": "GDUTTON_GEN",
+          "modifiedDateTime": [
+            2023,
+            2,
+            15,
+            15,
+            25,
+            3,
+            780000000
+          ],
+          "workTypesOfInterest": [
+            "HOSPITALITY",
+            "TECHNICAL",
+            "OTHER"
+          ],
+          "jobOfParticularInterest": "Some job",
+          "workTypesOfInterestOther": "Some other work"
+        },
+        "workExperience": {
+          "modifiedBy": "GDUTTON_GEN",
+          "modifiedDateTime": [
+            2023,
+            2,
+            15,
+            15,
+            25,
+            3,
+            780000000
+          ],
+          "qualificationsAndTraining": [
+            "DRIVING_LICENSE"
+          ],
+          "previousWorkOrVolunteering": "",
+          "qualificationsAndTrainingOther": ""
+        },
+        "actionsRequired": {
+          "actions": [
+            {
+              "id": null,
+              "status": "COMPLETED",
+              "todoItem": "BANK_ACCOUNT"
+            },
+            {
+              "id": null,
+              "status": "NOT_STARTED",
+              "todoItem": "EMAIL"
+            },
+            {
+              "id": null,
+              "status": "COMPLETED",
+              "todoItem": "HOUSING"
+            },
+            {
+              "id": [
+                "DRIVING_LICENCE"
+              ],
+              "status": "COMPLETED",
+              "todoItem": "ID"
+            },
+            {
+              "id": null,
+              "status": "IN_PROGRESS",
+              "todoItem": "CV_AND_COVERING_LETTER"
+            },
+            {
+              "id": null,
+              "status": "COMPLETED",
+              "todoItem": "DISCLOSURE_LETTER"
+            }
+          ],
+          "modifiedBy": "GDUTTON_GEN",
+          "modifiedDateTime": [
+            2023,
+            2,
+            15,
+            15,
+            26,
+            16,
+            253000000
+          ]
+        },
+        "modifiedDateTime": [
+          2023,
+          2,
+          15,
+          15,
+          27,
+          33,
+          197301225
+        ]
+      },
+      {
+        "modifiedBy": "GDUTTON_GEN",
+        "workImpacts": {
+          "modifiedBy": "GDUTTON_GEN",
+          "modifiedDateTime": [
+            2023,
+            2,
+            15,
+            15,
+            25,
+            34,
+            910000000
+          ],
+          "abilityToWorkImpactedBy": [
+            "EDUCATION_ENROLLMENT"
+          ],
+          "ableToManageDependencies": true,
+          "ableToManageMentalHealth": false,
+          "caringResponsibilitiesFullTime": false
+        },
+        "workInterests": {
+          "modifiedBy": "GDUTTON_GEN",
+          "modifiedDateTime": [
+            2023,
+            2,
+            15,
+            15,
+            25,
+            3,
+            780000000
+          ],
+          "workTypesOfInterest": [
+            "HOSPITALITY",
+            "TECHNICAL",
+            "OTHER"
+          ],
+          "jobOfParticularInterest": "Some job",
+          "workTypesOfInterestOther": "Some other work"
+        },
+        "workExperience": {
+          "modifiedBy": "GDUTTON_GEN",
+          "modifiedDateTime": [
+            2023,
+            2,
+            15,
+            15,
+            25,
+            3,
+            780000000
+          ],
+          "qualificationsAndTraining": [
+            "DRIVING_LICENSE"
+          ],
+          "previousWorkOrVolunteering": "modified the n-th (1) times",
+          "qualificationsAndTrainingOther": ""
+        },
+        "actionsRequired": {
+          "actions": [
+            {
+              "id": null,
+              "status": "COMPLETED",
+              "todoItem": "BANK_ACCOUNT"
+            },
+            {
+              "id": null,
+              "status": "NOT_STARTED",
+              "todoItem": "EMAIL"
+            },
+            {
+              "id": null,
+              "status": "COMPLETED",
+              "todoItem": "HOUSING"
+            },
+            {
+              "id": [
+                "DRIVING_LICENCE"
+              ],
+              "status": "COMPLETED",
+              "todoItem": "ID"
+            },
+            {
+              "id": null,
+              "status": "IN_PROGRESS",
+              "todoItem": "CV_AND_COVERING_LETTER"
+            },
+            {
+              "id": null,
+              "status": "COMPLETED",
+              "todoItem": "DISCLOSURE_LETTER"
+            }
+          ],
+          "modifiedBy": "GDUTTON_GEN",
+          "modifiedDateTime": [
+            2023,
+            2,
+            15,
+            15,
+            26,
+            16,
+            253000000
+          ]
+        },
+        "modifiedDateTime": [
+          2023,
+          2,
+          15,
+          15,
+          27,
+          33,
+          197301225
+        ]
+      },
+      {
+        "modifiedBy": "GDUTTON_GEN",
+        "workImpacts": {
+          "modifiedBy": "GDUTTON_GEN",
+          "modifiedDateTime": [
+            2023,
+            2,
+            15,
+            15,
+            25,
+            34,
+            910000000
+          ],
+          "abilityToWorkImpactedBy": [
+            "EDUCATION_ENROLLMENT"
+          ],
+          "ableToManageDependencies": true,
+          "ableToManageMentalHealth": false,
+          "caringResponsibilitiesFullTime": false
+        },
+        "workInterests": {
+          "modifiedBy": "GDUTTON_GEN",
+          "modifiedDateTime": [
+            2023,
+            2,
+            15,
+            15,
+            25,
+            3,
+            780000000
+          ],
+          "workTypesOfInterest": [
+            "HOSPITALITY",
+            "TECHNICAL",
+            "OTHER"
+          ],
+          "jobOfParticularInterest": "Some job",
+          "workTypesOfInterestOther": "Some other work"
+        },
+        "workExperience": {
+          "modifiedBy": "GDUTTON_GEN",
+          "modifiedDateTime": [
+            2023,
+            2,
+            15,
+            15,
+            25,
+            3,
+            780000000
+          ],
+          "qualificationsAndTraining": [
+            "DRIVING_LICENSE"
+          ],
+          "previousWorkOrVolunteering": "modified the n-th (2) times",
+          "qualificationsAndTrainingOther": ""
+        },
+        "actionsRequired": {
+          "actions": [
+            {
+              "id": null,
+              "status": "COMPLETED",
+              "todoItem": "BANK_ACCOUNT"
+            },
+            {
+              "id": null,
+              "status": "NOT_STARTED",
+              "todoItem": "EMAIL"
+            },
+            {
+              "id": null,
+              "status": "COMPLETED",
+              "todoItem": "HOUSING"
+            },
+            {
+              "id": [
+                "DRIVING_LICENCE"
+              ],
+              "status": "COMPLETED",
+              "todoItem": "ID"
+            },
+            {
+              "id": null,
+              "status": "IN_PROGRESS",
+              "todoItem": "CV_AND_COVERING_LETTER"
+            },
+            {
+              "id": null,
+              "status": "COMPLETED",
+              "todoItem": "DISCLOSURE_LETTER"
+            }
+          ],
+          "modifiedBy": "GDUTTON_GEN",
+          "modifiedDateTime": [
+            2023,
+            2,
+            15,
+            15,
+            26,
+            16,
+            253000000
+          ]
+        },
+        "modifiedDateTime": [
+          2023,
+          2,
+          15,
+          15,
+          27,
+          33,
+          197301225
+        ]
+      },
+      {
+        "modifiedBy": "GDUTTON_GEN",
+        "workImpacts": {
+          "modifiedBy": "GDUTTON_GEN",
+          "modifiedDateTime": [
+            2023,
+            2,
+            15,
+            15,
+            25,
+            34,
+            910000000
+          ],
+          "abilityToWorkImpactedBy": [
+            "EDUCATION_ENROLLMENT"
+          ],
+          "ableToManageDependencies": true,
+          "ableToManageMentalHealth": false,
+          "caringResponsibilitiesFullTime": false
+        },
+        "workInterests": {
+          "modifiedBy": "GDUTTON_GEN",
+          "modifiedDateTime": [
+            2023,
+            2,
+            15,
+            15,
+            25,
+            3,
+            780000000
+          ],
+          "workTypesOfInterest": [
+            "HOSPITALITY",
+            "TECHNICAL",
+            "OTHER"
+          ],
+          "jobOfParticularInterest": "Some job",
+          "workTypesOfInterestOther": "Some other work"
+        },
+        "workExperience": {
+          "modifiedBy": "GDUTTON_GEN",
+          "modifiedDateTime": [
+            2023,
+            2,
+            15,
+            15,
+            25,
+            3,
+            780000000
+          ],
+          "qualificationsAndTraining": [
+            "DRIVING_LICENSE"
+          ],
+          "previousWorkOrVolunteering": "modified the n-th (3) times",
+          "qualificationsAndTrainingOther": ""
+        },
+        "actionsRequired": {
+          "actions": [
+            {
+              "id": null,
+              "status": "COMPLETED",
+              "todoItem": "BANK_ACCOUNT"
+            },
+            {
+              "id": null,
+              "status": "NOT_STARTED",
+              "todoItem": "EMAIL"
+            },
+            {
+              "id": null,
+              "status": "COMPLETED",
+              "todoItem": "HOUSING"
+            },
+            {
+              "id": [
+                "DRIVING_LICENCE"
+              ],
+              "status": "COMPLETED",
+              "todoItem": "ID"
+            },
+            {
+              "id": null,
+              "status": "IN_PROGRESS",
+              "todoItem": "CV_AND_COVERING_LETTER"
+            },
+            {
+              "id": null,
+              "status": "COMPLETED",
+              "todoItem": "DISCLOSURE_LETTER"
+            }
+          ],
+          "modifiedBy": "GDUTTON_GEN",
+          "modifiedDateTime": [
+            2023,
+            2,
+            15,
+            15,
+            26,
+            16,
+            253000000
+          ]
+        },
+        "modifiedDateTime": [
+          2023,
+          2,
+          15,
+          15,
+          27,
+          33,
+          197301225
+        ]
+      },
+      {
+        "modifiedBy": "GDUTTON_GEN",
+        "workImpacts": {
+          "modifiedBy": "GDUTTON_GEN",
+          "modifiedDateTime": [
+            2023,
+            2,
+            15,
+            15,
+            25,
+            34,
+            910000000
+          ],
+          "abilityToWorkImpactedBy": [
+            "EDUCATION_ENROLLMENT"
+          ],
+          "ableToManageDependencies": true,
+          "ableToManageMentalHealth": false,
+          "caringResponsibilitiesFullTime": false
+        },
+        "workInterests": {
+          "modifiedBy": "GDUTTON_GEN",
+          "modifiedDateTime": [
+            2023,
+            2,
+            15,
+            15,
+            25,
+            3,
+            780000000
+          ],
+          "workTypesOfInterest": [
+            "HOSPITALITY",
+            "TECHNICAL",
+            "OTHER"
+          ],
+          "jobOfParticularInterest": "Some job",
+          "workTypesOfInterestOther": "Some other work"
+        },
+        "workExperience": {
+          "modifiedBy": "GDUTTON_GEN",
+          "modifiedDateTime": [
+            2023,
+            2,
+            15,
+            15,
+            25,
+            3,
+            780000000
+          ],
+          "qualificationsAndTraining": [
+            "DRIVING_LICENSE"
+          ],
+          "previousWorkOrVolunteering": "modified the n-th (4) times",
+          "qualificationsAndTrainingOther": ""
+        },
+        "actionsRequired": {
+          "actions": [
+            {
+              "id": null,
+              "status": "COMPLETED",
+              "todoItem": "BANK_ACCOUNT"
+            },
+            {
+              "id": null,
+              "status": "NOT_STARTED",
+              "todoItem": "EMAIL"
+            },
+            {
+              "id": null,
+              "status": "COMPLETED",
+              "todoItem": "HOUSING"
+            },
+            {
+              "id": [
+                "DRIVING_LICENCE"
+              ],
+              "status": "COMPLETED",
+              "todoItem": "ID"
+            },
+            {
+              "id": null,
+              "status": "IN_PROGRESS",
+              "todoItem": "CV_AND_COVERING_LETTER"
+            },
+            {
+              "id": null,
+              "status": "COMPLETED",
+              "todoItem": "DISCLOSURE_LETTER"
+            }
+          ],
+          "modifiedBy": "GDUTTON_GEN",
+          "modifiedDateTime": [
+            2023,
+            2,
+            15,
+            15,
+            26,
+            16,
+            253000000
+          ]
+        },
+        "modifiedDateTime": [
+          2023,
+          2,
+          15,
+          15,
+          27,
+          33,
+          197301225
+        ]
+      },
+      {
+        "modifiedBy": "GDUTTON_GEN",
+        "workImpacts": {
+          "modifiedBy": "GDUTTON_GEN",
+          "modifiedDateTime": [
+            2023,
+            2,
+            15,
+            15,
+            25,
+            34,
+            910000000
+          ],
+          "abilityToWorkImpactedBy": [
+            "EDUCATION_ENROLLMENT"
+          ],
+          "ableToManageDependencies": true,
+          "ableToManageMentalHealth": false,
+          "caringResponsibilitiesFullTime": false
+        },
+        "workInterests": {
+          "modifiedBy": "GDUTTON_GEN",
+          "modifiedDateTime": [
+            2023,
+            2,
+            15,
+            15,
+            25,
+            3,
+            780000000
+          ],
+          "workTypesOfInterest": [
+            "HOSPITALITY",
+            "TECHNICAL",
+            "OTHER"
+          ],
+          "jobOfParticularInterest": "Some job",
+          "workTypesOfInterestOther": "Some other work"
+        },
+        "workExperience": {
+          "modifiedBy": "GDUTTON_GEN",
+          "modifiedDateTime": [
+            2023,
+            2,
+            15,
+            15,
+            25,
+            3,
+            780000000
+          ],
+          "qualificationsAndTraining": [
+            "DRIVING_LICENSE"
+          ],
+          "previousWorkOrVolunteering": "modified the n-th (5) times",
+          "qualificationsAndTrainingOther": ""
+        },
+        "actionsRequired": {
+          "actions": [
+            {
+              "id": null,
+              "status": "COMPLETED",
+              "todoItem": "BANK_ACCOUNT"
+            },
+            {
+              "id": null,
+              "status": "NOT_STARTED",
+              "todoItem": "EMAIL"
+            },
+            {
+              "id": null,
+              "status": "COMPLETED",
+              "todoItem": "HOUSING"
+            },
+            {
+              "id": [
+                "DRIVING_LICENCE"
+              ],
+              "status": "COMPLETED",
+              "todoItem": "ID"
+            },
+            {
+              "id": null,
+              "status": "IN_PROGRESS",
+              "todoItem": "CV_AND_COVERING_LETTER"
+            },
+            {
+              "id": null,
+              "status": "COMPLETED",
+              "todoItem": "DISCLOSURE_LETTER"
+            }
+          ],
+          "modifiedBy": "GDUTTON_GEN",
+          "modifiedDateTime": [
+            2023,
+            2,
+            15,
+            15,
+            26,
+            16,
+            253000000
+          ]
+        },
+        "modifiedDateTime": [
+          2023,
+          2,
+          15,
+          15,
+          27,
+          33,
+          197301225
+        ]
+      }
+    ],
+    "supportDeclined": null,
+    "supportAccepted": {
+      "modifiedBy": "GDUTTON_GEN",
+      "workImpacts": {
+        "modifiedBy": "GDUTTON_GEN",
+        "modifiedDateTime": [
+          2023,
+          2,
+          15,
+          15,
+          25,
+          34,
+          910000000
+        ],
+        "abilityToWorkImpactedBy": [
+          "EDUCATION_ENROLLMENT"
+        ],
+        "ableToManageDependencies": true,
+        "ableToManageMentalHealth": false,
+        "caringResponsibilitiesFullTime": false
+      },
+      "workInterests": {
+        "modifiedBy": "GDUTTON_GEN",
+        "modifiedDateTime": [
+          2023,
+          2,
+          15,
+          15,
+          25,
+          3,
+          780000000
+        ],
+        "workTypesOfInterest": [
+          "HOSPITALITY",
+          "TECHNICAL",
+          "OTHER"
+        ],
+        "jobOfParticularInterest": "Some job",
+        "workTypesOfInterestOther": "Some other work"
+      },
+      "workExperience": {
+        "modifiedBy": "GDUTTON_GEN",
+        "modifiedDateTime": [
+          2023,
+          2,
+          15,
+          15,
+          25,
+          3,
+          780000000
+        ],
+        "qualificationsAndTraining": [
+          "DRIVING_LICENSE"
+        ],
+        "previousWorkOrVolunteering": "modified the n-th (6) times",
+        "qualificationsAndTrainingOther": ""
+      },
+      "actionsRequired": {
+        "actions": [
+          {
+            "id": null,
+            "status": "COMPLETED",
+            "todoItem": "BANK_ACCOUNT"
+          },
+          {
+            "id": null,
+            "status": "NOT_STARTED",
+            "todoItem": "EMAIL"
+          },
+          {
+            "id": null,
+            "status": "COMPLETED",
+            "todoItem": "HOUSING"
+          },
+          {
+            "id": [
+              "DRIVING_LICENCE"
+            ],
+            "status": "COMPLETED",
+            "todoItem": "ID"
+          },
+          {
+            "id": null,
+            "status": "IN_PROGRESS",
+            "todoItem": "CV_AND_COVERING_LETTER"
+          },
+          {
+            "id": null,
+            "status": "COMPLETED",
+            "todoItem": "DISCLOSURE_LETTER"
+          }
+        ],
+        "modifiedBy": "GDUTTON_GEN",
+        "modifiedDateTime": [
+          2023,
+          2,
+          15,
+          15,
+          26,
+          16,
+          253000000
+        ]
+      },
+      "modifiedDateTime": [
+        2023,
+        2,
+        15,
+        15,
+        27,
+        33,
+        197301225
+      ]
+    }
+  }
+}

--- a/src/integrationTest/resources/jsonprofile/CreateProfileDeclinedHistories.json
+++ b/src/integrationTest/resources/jsonprofile/CreateProfileDeclinedHistories.json
@@ -1,0 +1,98 @@
+{
+  "bookingId": "654321",
+  "profileData": {
+    "status": "SUPPORT_DECLINED",
+    "statusChange": false,
+    "statusChangeDate": null,
+    "prisonName": "prison2",
+    "statusChangeType": "NEW",
+    "supportDeclined_history": [
+      {
+        "modifiedBy": "test-client",
+        "modifiedDateTime": "2024-10-02T10:16:00.90103",
+        "supportToWorkDeclinedReason": [
+          "FULL_TIME_CARER"
+        ],
+        "supportToWorkDeclinedReasonOther": "another reason to decline support",
+        "circumstanceChangesRequiredToWork": [
+          "DEPENDENCY_SUPPORT"
+        ],
+        "circumstanceChangesRequiredToWorkOther": ""
+      },
+      {
+        "modifiedBy": "test-client",
+        "modifiedDateTime": "2024-10-02T10:16:01.90103",
+        "supportToWorkDeclinedReason": [
+          "FULL_TIME_CARER"
+        ],
+        "supportToWorkDeclinedReasonOther": "modified the n-th (1) times",
+        "circumstanceChangesRequiredToWork": [
+          "DEPENDENCY_SUPPORT"
+        ],
+        "circumstanceChangesRequiredToWorkOther": ""
+      },
+      {
+        "modifiedBy": "test-client",
+        "modifiedDateTime": "2024-10-02T10:16:02.90103",
+        "supportToWorkDeclinedReason": [
+          "FULL_TIME_CARER"
+        ],
+        "supportToWorkDeclinedReasonOther": "modified the n-th (2) times",
+        "circumstanceChangesRequiredToWork": [
+          "DEPENDENCY_SUPPORT"
+        ],
+        "circumstanceChangesRequiredToWorkOther": ""
+      },
+      {
+        "modifiedBy": "test-client",
+        "modifiedDateTime": "2024-10-02T10:16:03.90103",
+        "supportToWorkDeclinedReason": [
+          "FULL_TIME_CARER"
+        ],
+        "supportToWorkDeclinedReasonOther": "modified the n-th (3) times",
+        "circumstanceChangesRequiredToWork": [
+          "DEPENDENCY_SUPPORT"
+        ],
+        "circumstanceChangesRequiredToWorkOther": ""
+      },
+      {
+        "modifiedBy": "test-client",
+        "modifiedDateTime": "2024-10-02T10:16:04.90103",
+        "supportToWorkDeclinedReason": [
+          "FULL_TIME_CARER"
+        ],
+        "supportToWorkDeclinedReasonOther": "modified the n-th (4) times",
+        "circumstanceChangesRequiredToWork": [
+          "DEPENDENCY_SUPPORT"
+        ],
+        "circumstanceChangesRequiredToWorkOther": ""
+      },
+      {
+        "modifiedBy": "test-client",
+        "modifiedDateTime": "2024-10-02T10:16:05.90103",
+        "supportToWorkDeclinedReason": [
+          "FULL_TIME_CARER"
+        ],
+        "supportToWorkDeclinedReasonOther": "modified the n-th (5) times",
+        "circumstanceChangesRequiredToWork": [
+          "DEPENDENCY_SUPPORT"
+        ],
+        "circumstanceChangesRequiredToWorkOther": ""
+      }
+    ],
+    "supportAccepted_history": [],
+    "supportDeclined": {
+      "modifiedBy": "test-client",
+      "modifiedDateTime": "2024-10-02T10:16:06.90103",
+      "supportToWorkDeclinedReason": [
+        "FULL_TIME_CARER"
+      ],
+      "supportToWorkDeclinedReasonOther": "modified the n-th (6) times",
+      "circumstanceChangesRequiredToWork": [
+        "DEPENDENCY_SUPPORT"
+      ],
+      "circumstanceChangesRequiredToWorkOther": ""
+    },
+    "supportAccepted": null
+  }
+}

--- a/src/integrationTest/resources/jsonprofile/CreateProfile_correct.json
+++ b/src/integrationTest/resources/jsonprofile/CreateProfile_correct.json
@@ -1,0 +1,149 @@
+{
+  "bookingId": "123456",
+  "profileData": {
+    "status": "NO_RIGHT_TO_WORK",
+    "statusChange": false,
+    "statusChangeDate": null,
+    "prisonName":"prison2",
+    "statusChangeType": "NEW",
+    "supportDeclined_history": [
+      {
+        "modifiedBy": "sacintha-raj",
+        "modifiedDateTime": [
+          2022,
+          12,
+          18,
+          9,
+          15,
+          56,
+          460988000
+        ],
+        "supportToWorkDeclinedReason": [
+          "FULL_TIME_CARER"
+        ],
+        "supportToWorkDeclinedReasonOther": "",
+        "circumstanceChangesRequiredToWork": [
+          "DEPENDENCY_SUPPORT"
+        ],
+        "circumstanceChangesRequiredToWorkOther": ""
+      },
+      {
+        "modifiedBy": "sacintha-raj",
+        "modifiedDateTime": [
+          2022,
+          12,
+          18,
+          9,
+          15,
+          56,
+          460988000
+        ],
+        "supportToWorkDeclinedReason": [
+          "FULL_TIME_CARER"
+        ],
+        "supportToWorkDeclinedReasonOther": "",
+        "circumstanceChangesRequiredToWork": [
+          "DEPENDENCY_SUPPORT"
+        ],
+        "circumstanceChangesRequiredToWorkOther": ""
+      }
+    ],
+    "supportAccepted_history": [
+      {
+        "modifiedBy": null,
+        "modifiedDateTime": null,
+        "actionsRequired": {
+          "modifiedBy": "phil-whils",
+          "modifiedDateTime": [
+            2022,
+            12,
+            18,
+            9,
+            15,
+            56,
+            460988000
+          ],
+          "actions": [
+            {
+              "todoItem": "BANK_ACCOUNT",
+              "status": "COMPLETED"
+            }
+          ]
+        },
+        "workImpacts": {
+          "modifiedBy": "phil-whils",
+          "modifiedDateTime": [
+            2022,
+            12,
+            18,
+            9,
+            15,
+            56,
+            460988000
+          ],
+          "abilityToWorkImpactedBy": [
+            "CARING_RESPONSIBILITIES"
+          ],
+          "caringResponsibilitiesFullTime": true,
+          "ableToManageMentalHealth": true,
+          "ableToManageDependencies": true
+        },
+        "workInterests": {
+          "modifiedBy": "phil-whils",
+          "modifiedDateTime": [
+            2022,
+            12,
+            18,
+            9,
+            15,
+            56,
+            460988000
+          ],
+          "workTypesOfInterest": [
+            "CONSTRUCTION"
+          ],
+          "workTypesOfInterestOther": "freelance",
+          "jobOfParticularInterest": "architect"
+        },
+        "workExperience": {
+          "modifiedBy": "phil-whils",
+          "modifiedDateTime": [
+            2022,
+            12,
+            18,
+            9,
+            15,
+            56,
+            460988000
+          ],
+          "previousWorkOrVolunteering": "NONE",
+          "qualificationsAndTraining": [
+            "ADVANCED_EDUCATION"
+          ],
+          "qualificationsAndTrainingOther": "MBA"
+        }
+      }
+    ],
+    "supportDeclined": {
+      "modifiedBy": "sacintha-raj",
+      "modifiedDateTime": [
+        2022,
+        12,
+        18,
+        9,
+        16,
+        24,
+        581204000
+      ],
+      "supportToWorkDeclinedReason": [
+        "FULL_TIME_CARER"
+      ],
+      "supportToWorkDeclinedReasonOther": "",
+      "circumstanceChangesRequiredToWork": [
+        "DEPENDENCY_SUPPORT"
+      ],
+      "circumstanceChangesRequiredToWorkOther": ""
+    },
+    "supportAccepted": null
+  }
+}

--- a/src/integrationTest/resources/jsonprofile/sample2.json
+++ b/src/integrationTest/resources/jsonprofile/sample2.json
@@ -1,0 +1,115 @@
+{
+  "status": "NO_RIGHT_TO_WORK",
+  "statusChange": false,
+  "statusChangeDate": [
+    2022,
+    12,
+    18,
+    14,
+    7,
+    17,
+    738068000
+  ],
+  "prisonName":"prison2",
+  "statusChangeType": "ACCEPTED_TO_DECLINED",
+  "supportDeclined": null,
+  "supportAccepted": [
+    {
+      "modifiedBy": null,
+      "modifiedDateTime": null,
+      "actionsRequired": {
+        "modifiedBy": "phil-whils",
+        "modifiedDateTime": [
+          2022,
+          12,
+          18,
+          14,
+          7,
+          8,
+          5657000
+        ],
+        "actions": [
+          {
+            "todoItem": "BANK_ACCOUNT",
+            "status": "COMPLETED"
+          }
+        ]
+      },
+      "workImpacts": {
+        "modifiedBy": "phil-whils",
+        "modifiedDateTime": [
+          2022,
+          12,
+          18,
+          14,
+          7,
+          8,
+          5657000
+        ],
+        "abilityToWorkImpactedBy": [
+          "CARING_RESPONSIBILITIES"
+        ],
+        "caringResponsibilitiesFullTime": true,
+        "ableToManageMentalHealth": true,
+        "ableToManageDependencies": true
+      },
+      "workInterests": {
+        "modifiedBy": "phil-whils",
+        "modifiedDateTime": [
+          2022,
+          12,
+          18,
+          14,
+          7,
+          8,
+          5657000
+        ],
+        "workTypesOfInterest": [
+          "CONSTRUCTION"
+        ],
+        "workTypesOfInterestOther": "freelance",
+        "jobOfParticularInterest": "architect"
+      },
+      "workExperience": {
+        "modifiedBy": "phil-whils",
+        "modifiedDateTime": [
+          2022,
+          12,
+          18,
+          14,
+          7,
+          8,
+          5657000
+        ],
+        "previousWorkOrVolunteering": "NONE",
+        "qualificationsAndTraining": [
+          "ADVANCED_EDUCATION"
+        ],
+        "qualificationsAndTrainingOther": "MBA"
+      }
+    }
+  ],
+  "currentSupportState": {
+    "supportDeclined": {
+      "modifiedBy": "sacintha-raj",
+      "modifiedDateTime": [
+        2022,
+        12,
+        18,
+        14,
+        7,
+        47,
+        967213000
+      ],
+      "supportToWorkDeclinedReason": [
+        "FULL_TIME_CARER"
+      ],
+      "supportToWorkDeclinedReasonOther": "",
+      "circumstanceChangesRequiredToWork": [
+        "DEPENDENCY_SUPPORT"
+      ],
+      "circumstanceChangesRequiredToWorkOther": ""
+    },
+    "supportAccepted": null
+  }
+}

--- a/src/integrationTest/resources/jsonprofile/sampleReadinessprofile.json
+++ b/src/integrationTest/resources/jsonprofile/sampleReadinessprofile.json
@@ -1,0 +1,122 @@
+{
+  "status": "SUPPORT_NEEDED",
+  "statusChange": true,
+  "statusChangeDate": [
+    2022,
+    12,
+    18,
+    20,
+    47,
+    48,
+    247677000
+  ],
+  "statusChangeType": "DECLINED_TO_ACCEPTED",
+  "supportDeclined": [
+    {
+      "modifiedBy": "sacintha-raj",
+      "modifiedDateTime": [
+        2022,
+        12,
+        18,
+        20,
+        47,
+        7,
+        894279000
+      ],
+      "supportToWorkDeclinedReason": [
+        "FULL_TIME_CARER"
+      ],
+      "supportToWorkDeclinedReasonOther": "",
+      "circumstanceChangesRequiredToWork": [
+        "DEPENDENCY_SUPPORT"
+      ],
+      "circumstanceChangesRequiredToWorkOther": ""
+    }
+  ],
+  "supportAccepted": null,
+  "currentSupportState": {
+    "supportDeclined": null,
+    "supportAccepted": {
+      "modifiedBy": "sacintha-raj",
+      "modifiedDateTime": [
+        2022,
+        12,
+        18,
+        20,
+        47,
+        48,
+        247651000
+      ],
+      "actionsRequired": {
+        "modifiedBy": "phil-whils",
+        "modifiedDateTime": [
+          2022,
+          12,
+          18,
+          20,
+          47,
+          7,
+          894279000
+        ],
+        "actions": [
+          {
+            "todoItem": "CV_AND_COVERING_LETTER",
+            "status": "IN_PROGRESS"
+          }
+        ]
+      },
+      "workImpacts": {
+        "modifiedBy": "phil-whils",
+        "modifiedDateTime": [
+          2022,
+          12,
+          18,
+          20,
+          47,
+          7,
+          894279000
+        ],
+        "abilityToWorkImpactedBy": [
+          "CARING_RESPONSIBILITIES"
+        ],
+        "caringResponsibilitiesFullTime": true,
+        "ableToManageMentalHealth": true,
+        "ableToManageDependencies": true
+      },
+      "workInterests": {
+        "modifiedBy": "phil-whils",
+        "modifiedDateTime": [
+          2022,
+          12,
+          18,
+          20,
+          47,
+          7,
+          894279000
+        ],
+        "workTypesOfInterest": [
+          "CONSTRUCTION"
+        ],
+        "workTypesOfInterestOther": "freelance",
+        "jobOfParticularInterest": "architect"
+      },
+      "workExperience": {
+        "modifiedBy": "phil-whils",
+        "modifiedDateTime": [
+          2022,
+          12,
+          18,
+          20,
+          47,
+          7,
+          894279000
+        ],
+        "previousWorkOrVolunteering": "NONE",
+        "qualificationsAndTraining": [
+          "ADVANCED_EDUCATION"
+        ],
+        "qualificationsAndTrainingOther": "MBA"
+      }
+    }
+  }
+}

--- a/src/integrationTest/resources/jsonprofile/sampleprofile.json
+++ b/src/integrationTest/resources/jsonprofile/sampleprofile.json
@@ -1,0 +1,148 @@
+{
+  "status": "NO_RIGHT_TO_WORK",
+  "statusChange": false,
+  "statusChangeDate": null,
+  "prisonName":"prison2",
+  "statusChangeType": "NEW",
+  "supportDeclined": [
+    {
+      "modifiedBy": "sacintha-raj",
+      "modifiedDateTime": [
+        2022,
+        12,
+        18,
+        9,
+        15,
+        56,
+        460988000
+      ],
+      "supportToWorkDeclinedReason": [
+        "FULL_TIME_CARER"
+      ],
+      "supportToWorkDeclinedReasonOther": "",
+      "circumstanceChangesRequiredToWork": [
+        "DEPENDENCY_SUPPORT"
+      ],
+      "circumstanceChangesRequiredToWorkOther": ""
+    },
+    {
+      "modifiedBy": "sacintha-raj",
+      "modifiedDateTime": [
+        2022,
+        12,
+        18,
+        9,
+        15,
+        56,
+        460988000
+      ],
+      "supportToWorkDeclinedReason": [
+        "FULL_TIME_CARER"
+      ],
+      "supportToWorkDeclinedReasonOther": "",
+      "circumstanceChangesRequiredToWork": [
+        "DEPENDENCY_SUPPORT"
+      ],
+      "circumstanceChangesRequiredToWorkOther": ""
+    }
+  ],
+  "supportAccepted": [
+    {
+      "modifiedBy": null,
+      "modifiedDateTime": null,
+      "actionsRequired": {
+        "modifiedBy": "phil-whils",
+        "modifiedDateTime": [
+          2022,
+          12,
+          18,
+          9,
+          15,
+          56,
+          460988000
+        ],
+        "actions": [
+          {
+            "todoItem": "BANK_ACCOUNT",
+            "status": "COMPLETED"
+          }
+        ]
+      },
+      "workImpacts": {
+        "modifiedBy": "phil-whils",
+        "modifiedDateTime": [
+          2022,
+          12,
+          18,
+          9,
+          15,
+          56,
+          460988000
+        ],
+        "abilityToWorkImpactedBy": [
+          "CARING_RESPONSIBILITIES"
+        ],
+        "caringResponsibilitiesFullTime": true,
+        "ableToManageMentalHealth": true,
+        "ableToManageDependencies": true
+      },
+      "workInterests": {
+        "modifiedBy": "phil-whils",
+        "modifiedDateTime": [
+          2022,
+          12,
+          18,
+          9,
+          15,
+          56,
+          460988000
+        ],
+        "workTypesOfInterest": [
+          "CONSTRUCTION"
+        ],
+        "workTypesOfInterestOther": "freelance",
+        "jobOfParticularInterest": "architect"
+      },
+      "workExperience": {
+        "modifiedBy": "phil-whils",
+        "modifiedDateTime": [
+          2022,
+          12,
+          18,
+          9,
+          15,
+          56,
+          460988000
+        ],
+        "previousWorkOrVolunteering": "NONE",
+        "qualificationsAndTraining": [
+          "ADVANCED_EDUCATION"
+        ],
+        "qualificationsAndTrainingOther": "MBA"
+      }
+    }
+  ],
+  "currentSupportState": {
+    "supportDeclined": {
+      "modifiedBy": "sacintha-raj",
+      "modifiedDateTime": [
+        2022,
+        12,
+        18,
+        9,
+        16,
+        24,
+        581204000
+      ],
+      "supportToWorkDeclinedReason": [
+        "FULL_TIME_CARER"
+      ],
+      "supportToWorkDeclinedReasonOther": "",
+      "circumstanceChangesRequiredToWork": [
+        "DEPENDENCY_SUPPORT"
+      ],
+      "circumstanceChangesRequiredToWorkOther": ""
+    },
+    "supportAccepted": null
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/config/JpaConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/config/JpaConfig.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.educationemployment.api.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+
+@Configuration
+@EnableJpaAuditing
+class JpaConfig

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/entity/ReadinessProfile.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/entity/ReadinessProfile.kt
@@ -5,6 +5,7 @@ import jakarta.persistence.Column
 import jakarta.persistence.ColumnResult
 import jakarta.persistence.ConstructorResult
 import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
 import jakarta.persistence.Id
 import jakarta.persistence.NamedNativeQuery
 import jakarta.persistence.SqlResultSetMapping
@@ -17,6 +18,7 @@ import org.springframework.data.annotation.CreatedBy
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedBy
 import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import uk.gov.justice.digital.hmpps.educationemployment.api.data.SARReadinessProfileDTO
 import java.time.LocalDateTime
 
@@ -47,6 +49,7 @@ import java.time.LocalDateTime
 )
 @Audited
 @Entity
+@EntityListeners(AuditingEntityListener::class)
 @Table(name = "work_readiness")
 data class ReadinessProfile(
   @Id

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/service/ProfileService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/service/ProfileService.kt
@@ -16,12 +16,13 @@ import uk.gov.justice.digital.hmpps.educationemployment.api.exceptions.AlreadyEx
 import uk.gov.justice.digital.hmpps.educationemployment.api.exceptions.InvalidStateException
 import uk.gov.justice.digital.hmpps.educationemployment.api.exceptions.NotFoundException
 import uk.gov.justice.digital.hmpps.educationemployment.api.repository.ReadinessProfileRepository
+import uk.gov.justice.digital.hmpps.educationemployment.api.shared.domain.TimeProvider
 import java.time.LocalDate
-import java.time.LocalDateTime
 
 @Service
 class ProfileService(
   private val readinessProfileRepository: ReadinessProfileRepository,
+  private val timeProvider: TimeProvider,
 ) {
   fun createProfileForOffender(
     userId: String,
@@ -45,9 +46,9 @@ class ProfileService(
         offenderId,
         bookingId,
         userId,
-        LocalDateTime.now(),
+        timeProvider.now(),
         userId,
-        LocalDateTime.now(),
+        timeProvider.now(),
         "1.0",
         CapturedSpringConfigValues.objectMapper.readTree(CapturedSpringConfigValues.objectMapper.writeValueAsString(profile)),
         CapturedSpringConfigValues.objectMapper.readTree("[]"),
@@ -95,7 +96,7 @@ class ProfileService(
     storedProfile.profileData =
       CapturedSpringConfigValues.objectMapper.readTree(CapturedSpringConfigValues.objectMapper.writeValueAsString(profile))
     storedProfile.modifiedBy = userId
-    storedProfile.modifiedDateTime = LocalDateTime.now()
+    storedProfile.modifiedDateTime = timeProvider.now()
     readinessProfileRepository.save(storedProfile)
     return storedProfile
   }
@@ -175,7 +176,7 @@ class ProfileService(
       CapturedSpringConfigValues.objectMapper.writeValueAsString(storedProfile.notesData),
       object : TypeReference<MutableList<Note>>() {},
     )
-    notesList.add(Note(userId, LocalDateTime.now(), attribute, text))
+    notesList.add(Note(userId, timeProvider.now(), attribute, text))
     storedProfile.notesData =
       CapturedSpringConfigValues.objectMapper.readTree(CapturedSpringConfigValues.objectMapper.writeValueAsString(notesList))
     storedProfile.modifiedBy = userId
@@ -203,12 +204,12 @@ class ProfileService(
   fun setMiscellaneousAttributesOnSupportState(profile: Profile, userId: String, offenderId: String) {
     if (profile.supportAccepted != null) {
       profile.supportAccepted?.modifiedBy = userId
-      profile.supportAccepted?.modifiedDateTime = LocalDateTime.now()
+      profile.supportAccepted?.modifiedDateTime = timeProvider.now()
     }
 
     if (profile.supportDeclined != null) {
       profile.supportDeclined?.modifiedBy = userId
-      profile.supportDeclined?.modifiedDateTime = LocalDateTime.now()
+      profile.supportDeclined?.modifiedDateTime = timeProvider.now()
       checkDeclinedProfileStatus(profile, offenderId)
     }
   }
@@ -224,7 +225,7 @@ class ProfileService(
       object : TypeReference<Profile>() {},
     )
     checkDeclinedProfileStatus(profile, offenderId)
-    profile.statusChangeDate = LocalDateTime.now()
+    profile.statusChangeDate = timeProvider.now()
     profile.statusChangeType = StatusChange.DECLINED_TO_ACCEPTED
 
     profile.supportDeclined_history?.let { it.add(profile.supportDeclined!!) } ?: run {
@@ -233,7 +234,7 @@ class ProfileService(
     }
     profile.supportDeclined = null
     statusChangeUpdateRequestDTO.supportAccepted!!.modifiedBy = userId
-    statusChangeUpdateRequestDTO.supportAccepted.modifiedDateTime = LocalDateTime.now()
+    statusChangeUpdateRequestDTO.supportAccepted.modifiedDateTime = timeProvider.now()
     profile.supportAccepted = statusChangeUpdateRequestDTO.supportAccepted
     profile.status = statusChangeUpdateRequestDTO.status
 
@@ -245,7 +246,7 @@ class ProfileService(
     profileToBeModified.supportAccepted = profileReference.supportAccepted
     profileToBeModified.supportAccepted_history = profileReference.supportAccepted_history
     profileToBeModified.supportDeclined_history = profileReference.supportDeclined_history
-    profileToBeModified.statusChangeDate = LocalDateTime.now()
+    profileToBeModified.statusChangeDate = timeProvider.now()
     profileToBeModified.statusChange = true
     profileToBeModified.statusChangeType = profileReference.statusChangeType
   }
@@ -276,12 +277,12 @@ class ProfileService(
       throw InvalidStateException(offenderId)
     }
 
-    storedCoreProfile.statusChangeDate = LocalDateTime.now()
+    storedCoreProfile.statusChangeDate = timeProvider.now()
     storedCoreProfile.statusChange = true
     storedProfile.profileData =
       CapturedSpringConfigValues.objectMapper.readTree(CapturedSpringConfigValues.objectMapper.writeValueAsString(storedCoreProfile))
     storedProfile.modifiedBy = userId
-    storedProfile.modifiedDateTime = LocalDateTime.now()
+    storedProfile.modifiedDateTime = timeProvider.now()
     readinessProfileRepository.save(storedProfile)
     return storedProfile
   }
@@ -295,7 +296,7 @@ class ProfileService(
       CapturedSpringConfigValues.objectMapper.writeValueAsString(storedProfile.profileData),
       object : TypeReference<Profile>() {},
     )
-    profile.statusChangeDate = LocalDateTime.now()
+    profile.statusChangeDate = timeProvider.now()
     profile.statusChangeType = StatusChange.ACCEPTED_TO_DECLINED
 
     profile.supportAccepted_history?.let { it.add(profile.supportAccepted!!) } ?: run {
@@ -304,7 +305,7 @@ class ProfileService(
     }
     // profile.supportAccepted = null
     statusChangeUpdateRequestDTO.supportDeclined!!.modifiedBy = userId
-    statusChangeUpdateRequestDTO.supportDeclined.modifiedDateTime = LocalDateTime.now()
+    statusChangeUpdateRequestDTO.supportDeclined.modifiedDateTime = timeProvider.now()
     profile.supportDeclined = statusChangeUpdateRequestDTO.supportDeclined
     profile.status = statusChangeUpdateRequestDTO.status
     checkDeclinedProfileStatus(profile, offenderId)
@@ -342,7 +343,7 @@ class ProfileService(
   fun updateAcceptedStatusList(profile: Profile, storedCoreProfile: Profile, userId: String, offenderId: String) {
     profile.supportAccepted?.modifiedBy = userId
     profile.supportAccepted?.modifiedBy = userId
-    profile.supportAccepted?.modifiedDateTime = LocalDateTime.now()
+    profile.supportAccepted?.modifiedDateTime = timeProvider.now()
     profile.supportAccepted_history?.let { it.add(storedCoreProfile.supportAccepted!!) } ?: run {
       profile.supportAccepted_history = mutableListOf<SupportAccepted>()
       profile.supportAccepted_history!!.add(storedCoreProfile.supportAccepted!!)
@@ -352,7 +353,7 @@ class ProfileService(
   fun updateDeclinedStatusList(profile: Profile, storedCoreProfile: Profile, userId: String, offenderId: String) {
     profile.supportAccepted?.modifiedBy = userId
     profile.supportDeclined?.modifiedBy = userId
-    profile.supportDeclined?.modifiedDateTime = LocalDateTime.now()
+    profile.supportDeclined?.modifiedDateTime = timeProvider.now()
     profile.supportDeclined_history?.let { it.add(storedCoreProfile.supportDeclined!!) } ?: run {
       profile.supportDeclined_history = mutableListOf<SupportDeclined>()
       profile.supportDeclined_history!!.add(storedCoreProfile.supportDeclined!!)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/shared/application/DefaultTimeProvider.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/shared/application/DefaultTimeProvider.kt
@@ -1,0 +1,13 @@
+package uk.gov.justice.digital.hmpps.educationemployment.api.shared.application
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.educationemployment.api.shared.domain.TimeProvider
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+@Component
+class DefaultTimeProvider(
+  override val timezoneId: ZoneId = ZoneId.systemDefault(),
+) : TimeProvider {
+  override fun now(): LocalDateTime = LocalDateTime.now()
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/shared/domain/TimeProvider.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/shared/domain/TimeProvider.kt
@@ -1,0 +1,15 @@
+package uk.gov.justice.digital.hmpps.educationemployment.api.shared.domain
+
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+interface TimeProvider {
+  val timezoneId: ZoneId
+
+  fun now(): LocalDateTime
+
+  fun nowAsInstant(): Instant = now().atZone(timezoneId).toInstant()
+
+  fun today() = now().toLocalDate()
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/audit/domain/AuditObjects.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/audit/domain/AuditObjects.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.educationemployment.api.audit.domain
+
+import java.time.Instant
+import java.time.ZoneId
+
+object AuditObjects {
+  val username = "auser_gen"
+  val displayName = "John Doe"
+  val system = "system"
+
+  val defaultAuditor = username
+
+  val defaultAuditTime = Instant.parse("2025-01-01T00:00:00.00Z")
+  val defaultTimezoneId = ZoneId.of("Z")
+  val defaultAuditLocalTime = defaultAuditTime.atZone(defaultTimezoneId).toLocalDateTime()
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/service/ProfileServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/service/ProfileServiceTest.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.educationemployment.api.service
 import com.fasterxml.jackson.core.type.TypeReference
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentCaptor
 import org.mockito.InjectMocks
@@ -34,11 +33,6 @@ class ProfileServiceTest : UnitTestBase() {
 
   @InjectMocks
   private lateinit var profileService: ProfileService
-
-  @BeforeEach
-  fun beforeEach() {
-    profileService = ProfileService(readinessProfileRepository, timeProvider)
-  }
 
   @Test
   fun `makes a call to the repository to save the readiness profile`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/shared/application/UnitTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/shared/application/UnitTestBase.kt
@@ -1,0 +1,30 @@
+package uk.gov.justice.digital.hmpps.educationemployment.api.shared.application
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.Mockito.lenient
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.educationemployment.api.shared.domain.TimeProvider
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZoneOffset
+
+@ExtendWith(MockitoExtension::class)
+abstract class UnitTestBase {
+  @Mock
+  protected lateinit var timeProvider: TimeProvider
+
+  protected val defaultTimeZoneOffset = ZoneOffset.UTC
+  protected val defaultTimeZone: ZoneId = defaultTimeZoneOffset
+  protected val defaultCurrentLocalTime = LocalDateTime.of(2025, 1, 1, 1, 1, 1)
+  protected val defaultCurrentTime: Instant by lazy { defaultCurrentLocalTime.atZone(defaultTimeZone).toInstant() }
+
+  @BeforeEach
+  internal open fun setUpBase() {
+    lenient().whenever(timeProvider.nowAsInstant()).thenReturn(defaultCurrentTime)
+    lenient().whenever(timeProvider.now()).thenReturn(defaultCurrentLocalTime)
+  }
+}


### PR DESCRIPTION
audit
- enable JPA auditing (at `JpaConfig`)
- add `AuditingEntityListener` to `ReadinessProfile`

refactor tests
- add test objects (`AuditObjects`, `ProfileObjects`)
- extract `LocalDatetime.now()` to `TimeProvider` (for testability)
- share test base: `UnitTestBase`, `ApplicationTestCase`, `RepositoryTestCase`
- fix nullability warnings
- duplicate test data files and isolate between unit and integration tests