### PR TITLE
[ESWE-1153] Metric Reasons for support declined

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/config/ExceptionAdvice.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/config/ExceptionAdvice.kt
@@ -16,6 +16,7 @@ import org.springframework.web.client.RestClientException
 import org.springframework.web.client.RestClientResponseException
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
 import uk.gov.justice.digital.hmpps.educationemployment.api.exceptions.AlreadyExistsException
+import uk.gov.justice.digital.hmpps.educationemployment.api.exceptions.CustomValidationException
 import uk.gov.justice.digital.hmpps.educationemployment.api.exceptions.DeprecatedApiException
 import uk.gov.justice.digital.hmpps.educationemployment.api.exceptions.NotFoundException
 import java.util.*
@@ -180,6 +181,12 @@ class ControllerAdvice {
     return HttpStatus.GONE.let {
       makeErrorResponse(e, it, userMessage = "${it.reasonPhrase}: This API is no longer supported")
     }
+  }
+
+  @ExceptionHandler(CustomValidationException::class)
+  fun handleCustomValidationException(e: CustomValidationException): ResponseEntity<ErrorResponse> {
+    log.info("CustomValidationException: ${e.message}", e)
+    return makeErrorResponse(e, userMessage = "Validation failure: ${e.message}")
   }
 
   @ExceptionHandler(java.lang.Exception::class)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/exceptions/CommonExceptions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/exceptions/CommonExceptions.kt
@@ -17,3 +17,5 @@ class InvalidStateException(var offenderId: String) :
 }
 
 class DeprecatedApiException : Exception("The API has been deprecated and is no longer supported.")
+
+class CustomValidationException(message: String) : Exception(message)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/readinessprofile/application/ProfileMetricsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/readinessprofile/application/ProfileMetricsService.kt
@@ -35,7 +35,7 @@ class ProfileMetricsService(
 }
 
 data class GetMetricsReasonsSupportDeclinedResponse(
-  val supportToWorkDeclinedReason: String?,
+  val supportToWorkDeclinedReason: String,
   val numberOfPrisonersWithin12Weeks: Long,
   val numberOfPrisonersOver12Weeks: Long,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/readinessprofile/application/ProfileMetricsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/readinessprofile/application/ProfileMetricsService.kt
@@ -1,0 +1,41 @@
+package uk.gov.justice.digital.hmpps.educationemployment.api.readinessprofile.application
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.educationemployment.api.readinessprofile.domain.ReadinessProfileRepository
+import uk.gov.justice.digital.hmpps.educationemployment.api.shared.domain.TimeProvider
+import uk.gov.justice.digital.hmpps.educationemployment.api.shared.infrastructure.MetricsCountByStringField
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.temporal.ChronoUnit
+
+@Service
+class ProfileMetricsService(
+  private val readinessProfileRepository: ReadinessProfileRepository,
+  private val timeProvider: TimeProvider,
+) {
+  private val atEndOfDay = LocalTime.MAX.truncatedTo(ChronoUnit.MICROS)
+
+  fun retrieveMetricsReasonsSupportDeclinedByPrisonIdAndDates(
+    prisonId: String,
+    dateFrom: LocalDate,
+    dateTo: LocalDate,
+  ): List<GetMetricsReasonsSupportDeclinedResponse> = readinessProfileRepository.countReasonsForSupportDeclinedByPrisonIdAndDateTimeBetween(
+    prisonId,
+    startTime = dateFrom.startAt,
+    endTime = dateTo.endAt,
+  ).reasonsSupportDeclinedResponses()
+
+  private val LocalDate.startAt: Instant get() = this.atStartOfDay().instant
+  private val LocalDate.endAt: Instant get() = this.atTime(atEndOfDay).instant
+  private val LocalDateTime.instant: Instant get() = this.atZone(timeProvider.timezoneId).toInstant()
+
+  private fun List<MetricsCountByStringField>.reasonsSupportDeclinedResponses() = this.map { GetMetricsReasonsSupportDeclinedResponse(it.field, it.countWithin12Weeks, it.countOver12Weeks) }
+}
+
+data class GetMetricsReasonsSupportDeclinedResponse(
+  val supportToWorkDeclinedReason: String?,
+  val numberOfPrisonersWithin12Weeks: Long,
+  val numberOfPrisonersOver12Weeks: Long,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/readinessprofile/domain/ReadinessProfileRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/readinessprofile/domain/ReadinessProfileRepository.kt
@@ -15,19 +15,32 @@ interface ReadinessProfileRepository :
   @Query(
     """
     WITH recent_updates AS (
-      SELECT rev_number, offender_id FROM work_readiness_audit wra
+      SELECT rev_number, offender_id, profile_data FROM work_readiness_audit wra
       WHERE wra.modified_date_time BETWEEN :startTime AND :endTime AND wra.rev_type IN (0,1)
+    ), profile_at_start AS (
+      SELECT wra1.rev_number, wra1.offender_id, wra1.profile_data FROM work_readiness_audit wra1
+      INNER JOIN (
+        SELECT offender_id, max(rev_number) as rev_number 
+        FROM work_readiness_audit wra2
+        WHERE wra2.offender_id IN (SELECT DISTINCT offender_id from recent_updates) AND wra2.modified_date_time <= :startTime AND wra2.rev_type IN (0,1)
+        GROUP BY 1
+      ) at_start 
+      ON wra1.offender_id = at_start.offender_id AND at_start.rev_number = at_start.rev_number
+      AND at_start.rev_number NOT IN (SELECT rev_number from recent_updates)
+    ), profile_snapshots AS (
+      SELECT * FROM recent_updates UNION ALL SELECT * FROM profile_at_start
     ), latest AS (
-      SELECT offender_id, MAX(rev_number) AS rev_number FROM recent_updates GROUP BY offender_id
+      SELECT offender_id, MAX(rev_number) AS rev_number, BOOL_OR(COALESCE((profile_data->>'within12Weeks')::boolean, true)) as within_12_weeks
+      FROM profile_snapshots GROUP BY offender_id
     ), latest_profiles AS (
-      SELECT wra.offender_id, 
-        wra.profile_data->>'prisonId' AS prison_id,
-        COALESCE((wra.profile_data->>'within12Weeks')::boolean, true) AS within_12_weeks,
-        wra.profile_data#>'{supportDeclined, supportToWorkDeclinedReason}' AS declined_reasons
-      FROM work_readiness_audit wra INNER JOIN latest l
-      ON L.offender_id = wra.offender_id AND l.rev_number = wra.rev_number
-      WHERE wra.profile_data->>'status' = 'SUPPORT_DECLINED'
-      AND wra.profile_data->>'prisonId' = :prisonId
+      SELECT p.offender_id, 
+        p.profile_data->>'prisonId' AS prison_id,
+        l.within_12_weeks,
+        p.profile_data#>'{supportDeclined, supportToWorkDeclinedReason}' AS declined_reasons
+      FROM profile_snapshots p INNER JOIN latest l
+      ON L.offender_id = p.offender_id AND l.rev_number = p.rev_number
+      WHERE p.profile_data->>'status' = 'SUPPORT_DECLINED'
+      AND p.profile_data->>'prisonId' = :prisonId
     ), declined_reasons AS (
       SELECT p.offender_id, p.within_12_weeks, dr.value AS declined_reason FROM latest_profiles p, jsonb_array_elements_text(declined_reasons) AS dr
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/readinessprofile/domain/ReadinessProfileRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/readinessprofile/domain/ReadinessProfileRepository.kt
@@ -1,10 +1,46 @@
 package uk.gov.justice.digital.hmpps.educationemployment.api.readinessprofile.domain
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.history.RevisionRepository
 import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.educationemployment.api.shared.infrastructure.MetricsCountByStringField
+import java.time.Instant
 
 @Repository
 interface ReadinessProfileRepository :
   JpaRepository<ReadinessProfile, String>,
-  RevisionRepository<ReadinessProfile, String, Long>
+  RevisionRepository<ReadinessProfile, String, Long> {
+
+  @Query(
+    """
+    WITH recent_updates AS (
+      SELECT rev_number, offender_id FROM work_readiness_audit wra
+      WHERE wra.modified_date_time BETWEEN :startTime AND :endTime AND wra.rev_type IN (0,1)
+    ), latest AS (
+      SELECT offender_id, MAX(rev_number) AS rev_number FROM recent_updates GROUP BY offender_id
+    ), latest_profiles AS (
+      SELECT wra.offender_id, 
+        wra.profile_data->>'prisonId' AS prison_id,
+        COALESCE((wra.profile_data->>'within12Weeks')::boolean, true) AS within_12_weeks,
+        wra.profile_data#>'{supportDeclined, supportToWorkDeclinedReason}' AS declined_reasons
+      FROM work_readiness_audit wra INNER JOIN latest l
+      ON L.offender_id = wra.offender_id AND l.rev_number = wra.rev_number
+      WHERE wra.profile_data->>'status' = 'SUPPORT_DECLINED'
+      AND wra.profile_data->>'prisonId' = :prisonId
+    ), declined_reasons AS (
+      SELECT p.offender_id, p.within_12_weeks, dr.value AS declined_reason FROM latest_profiles p, jsonb_array_elements_text(declined_reasons) AS dr
+    )
+    SELECT declined_reason as field,
+      COUNT(CASE within_12_weeks WHEN TRUE THEN 1 ELSE 0 END) AS countWithin12Weeks,
+      COUNT(CASE within_12_weeks WHEN FALSE THEN 1 ELSE 0 END) AS countOver12Weeks
+    FROM declined_reasons GROUP BY 1 ORDER BY 1;
+    """,
+    nativeQuery = true,
+  )
+  fun countReasonsForSupportDeclinedByPrisonIdAndDateTimeBetween(
+    prisonId: String,
+    startTime: Instant,
+    endTime: Instant,
+  ): List<MetricsCountByStringField>
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/readinessprofile/domain/ReadinessProfileRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/readinessprofile/domain/ReadinessProfileRepository.kt
@@ -47,7 +47,9 @@ interface ReadinessProfileRepository :
     SELECT declined_reason as field,
       COUNT(CASE within_12_weeks WHEN TRUE THEN 1 ELSE 0 END) AS countWithin12Weeks,
       COUNT(CASE within_12_weeks WHEN FALSE THEN 1 ELSE 0 END) AS countOver12Weeks
-    FROM declined_reasons GROUP BY 1 ORDER BY 1;
+    FROM declined_reasons 
+    WHERE declined_reason IS NOT NULL 
+    GROUP BY 1 ORDER BY 1;
     """,
     nativeQuery = true,
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/resource/dashboard/DashboardGet.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/resource/dashboard/DashboardGet.kt
@@ -1,0 +1,88 @@
+package uk.gov.justice.digital.hmpps.educationemployment.api.resource.dashboard
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.ArraySchema
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import org.springframework.format.annotation.DateTimeFormat
+import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.educationemployment.api.config.ErrorResponse
+import uk.gov.justice.digital.hmpps.educationemployment.api.exceptions.CustomValidationException
+import uk.gov.justice.digital.hmpps.educationemployment.api.readinessprofile.application.GetMetricsReasonsSupportDeclinedResponse
+import uk.gov.justice.digital.hmpps.educationemployment.api.readinessprofile.application.ProfileMetricsService
+import java.time.LocalDate
+
+@Validated
+@RestController
+@RequestMapping("/dashboard", produces = [APPLICATION_JSON_VALUE])
+@PreAuthorize("hasAnyRole('WORK_READINESS_EDIT','WORK_READINESS_VIEW')")
+class DashboardGet(
+  private val profileMetricsService: ProfileMetricsService,
+) {
+  @GetMapping("/reasons-support-declined")
+  @Operation(
+    summary = "Retrieve metrics Reasons for support declined, of given prison",
+    description = "requires role ${DESC_READ_ONLY_ROLES}",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "The success status is set as the request has been processed correctly.",
+        content = [
+          Content(
+            mediaType = "application/json",
+            array = ArraySchema(schema = Schema(implementation = GetMetricsReasonsSupportDeclinedResponse::class)),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "The failure status is set when the request is invalid. An error response will be provided.",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Error: Unauthorised. The error status is set as the required authorisation was not provided.",
+        content = [Content()],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Error: Access Denied. The error status is set as the required system role(s) was/were not found.",
+        content = [Content()],
+      ),
+    ],
+  )
+  fun retrieveMetricsLatestApplications(
+    @RequestParam(required = true)
+    @Parameter(description = "The identifier of the given prison.", example = "MDI")
+    prisonId: String,
+    @RequestParam(required = true)
+    @Parameter(description = "The start date of reporting period (in ISO-8601 date format)", example = "2024-01-01")
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    dateFrom: LocalDate,
+    @RequestParam(required = true)
+    @Parameter(description = "The end date of reporting period (in ISO-8601 date format)", example = "2024-01-31")
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    dateTo: LocalDate,
+  ): ResponseEntity<Any> {
+    validateDatePeriod(dateFrom, dateTo)?.let { errorMessage -> throw CustomValidationException(errorMessage) }
+
+    val response = profileMetricsService.retrieveMetricsReasonsSupportDeclinedByPrisonIdAndDates(prisonId, dateFrom, dateTo)
+    return ResponseEntity.ok(response)
+  }
+
+  private fun validateDatePeriod(dateFrom: LocalDate, dateTo: LocalDate): String? = when {
+    dateFrom.isAfter(dateTo) -> "dateFrom ($dateFrom) cannot be after dateTo ($dateTo)"
+    else -> null
+  }
+}
+
+private const val DESC_READ_ONLY_ROLES = "<b>WORK_READINESS_VIEW</b> or <b>WORK_READINESS_EDIT</b>"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/shared/infrastructure/MetricsCountByFields.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/shared/infrastructure/MetricsCountByFields.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.educationemployment.api.shared.infrastructure
+
+interface MetricsCountByField<T> {
+  val field: T
+  val countWithin12Weeks: Long
+  val countOver12Weeks: Long
+}
+
+interface MetricsCountByStringField : MetricsCountByField<String>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/readinessprofile/application/ProfileMetricsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/readinessprofile/application/ProfileMetricsServiceTest.kt
@@ -1,0 +1,72 @@
+package uk.gov.justice.digital.hmpps.educationemployment.api.readinessprofile.application
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.lenient
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.educationemployment.api.profiledata.domain.SupportToWorkDeclinedReason
+import uk.gov.justice.digital.hmpps.educationemployment.api.readinessprofile.domain.ReadinessProfileRepository
+import uk.gov.justice.digital.hmpps.educationemployment.api.shared.application.UnitTestBase
+import uk.gov.justice.digital.hmpps.educationemployment.api.shared.infrastructure.MetricsCountForTest
+import java.time.LocalDate
+import kotlin.test.assertContentEquals
+
+class ProfileMetricsServiceTest : UnitTestBase() {
+  @Mock
+  private lateinit var readinessProfileRepository: ReadinessProfileRepository
+
+  @InjectMocks
+  private lateinit var profileMetricsService: ProfileMetricsService
+
+  private val prisonId = "MDI"
+  private val dateFrom = LocalDate.of(2021, 1, 1)
+  private val dateTo = LocalDate.of(2021, 1, 31)
+
+  @Nested
+  @DisplayName("Given none of readiness profile")
+  inner class GivenNoProfile {
+    @BeforeEach
+    internal fun setUp() {
+      lenient().whenever(readinessProfileRepository.countReasonsForSupportDeclinedByPrisonIdAndDateTimeBetween(eq(prisonId), any(), any()))
+        .thenReturn(emptyList())
+    }
+
+    @Test
+    fun `return nothing for metric - Reasons for not wanting support`() {
+      val actual = profileMetricsService.retrieveMetricsReasonsSupportDeclinedByPrisonIdAndDates(prisonId, dateFrom, dateTo)
+      assertThat(actual).isEmpty()
+    }
+  }
+
+  @Nested
+  @DisplayName("Given some existing readiness profiles")
+  inner class GivenExistingProfiles {
+    @Test
+    fun `return counts for metric - Reasons for not wanting support`() {
+      val metricCounts = listOf(
+        makeMetricsCount(SupportToWorkDeclinedReason.HEALTH, 11, 2),
+        makeMetricsCount(SupportToWorkDeclinedReason.RETIRED, 5, 8),
+        makeMetricsCount(SupportToWorkDeclinedReason.LIMIT_THEIR_ABILITY, 3, 4),
+      )
+      whenever(readinessProfileRepository.countReasonsForSupportDeclinedByPrisonIdAndDateTimeBetween(eq(prisonId), any(), any())).thenReturn(metricCounts)
+      val expected = metricCounts.map { it.reasonsDeclinedResponse() }.toList()
+
+      val actual = profileMetricsService.retrieveMetricsReasonsSupportDeclinedByPrisonIdAndDates(prisonId, dateFrom, dateTo)
+
+      assertContentEquals(expected, actual)
+    }
+  }
+
+  private fun makeMetricsCount(reasonForSupportDeclined: SupportToWorkDeclinedReason, countWithin12Weeks: Long, countOver12Weeks: Long) = makeMetricsCount(reasonForSupportDeclined.name, countWithin12Weeks, countOver12Weeks)
+
+  private fun makeMetricsCount(field: String, countWithin12Weeks: Long = 0, countOver12Weeks: Long = 0) = MetricsCountForTest(field, countWithin12Weeks, countOver12Weeks)
+
+  private fun MetricsCountForTest.reasonsDeclinedResponse() = GetMetricsReasonsSupportDeclinedResponse(field, countWithin12Weeks, countOver12Weeks)
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/shared/application/UnitTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/shared/application/UnitTestBase.kt
@@ -39,6 +39,7 @@ abstract class UnitTestBase {
   internal open fun setUpBase() {
     lenient().whenever(timeProvider.nowAsInstant()).thenReturn(defaultCurrentTime)
     lenient().whenever(timeProvider.now()).thenReturn(defaultCurrentLocalTime)
+    lenient().whenever(timeProvider.timezoneId).thenReturn(defaultTimeZoneOffset)
   }
 
   companion object {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/shared/infrastructure/MetricsCountForTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/shared/infrastructure/MetricsCountForTest.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.educationemployment.api.shared.infrastructure
+
+data class MetricsCountForTest(
+  override val field: String,
+  override val countWithin12Weeks: Long,
+  override val countOver12Weeks: Long,
+) : MetricsCountByStringField


### PR DESCRIPTION
Dashboard metric: Reasons for support declined (not wanting support)
* Native query at readiness profile repository
* Metrics service
* Metrics API
* a few simple unit tests