### PR TITLE
[ESWE-1271] v2 APIs at default path

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/integration/resource/v1/ReadinessProfileV1TestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/integration/resource/v1/ReadinessProfileV1TestCase.kt
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.databind.JsonNode
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.core.ParameterizedTypeReference
 import uk.gov.justice.digital.hmpps.educationemployment.api.integration.helpers.ProfileV1Helper
-import uk.gov.justice.digital.hmpps.educationemployment.api.integration.resource.READINESS_PROFILE_ENDPOINT
 import uk.gov.justice.digital.hmpps.educationemployment.api.integration.resource.ReadinessProfileTestCase
 import uk.gov.justice.digital.hmpps.educationemployment.api.profiledata.domain.v1.Profile
 import uk.gov.justice.digital.hmpps.educationemployment.api.readinessprofile.application.v1.ReadinessProfileDTO
@@ -15,7 +14,7 @@ import uk.gov.justice.digital.hmpps.educationemployment.api.readinessprofile.app
 
 abstract class ReadinessProfileV1TestCase :
   ReadinessProfileTestCase<ReadinessProfileDTO, ReadinessProfileRequestDTO>(
-    READINESS_PROFILE_ENDPOINT,
+    READINESS_PROFILE_V1_ENDPOINT,
     ReadinessProfileDTO::class.java,
     object : TypeReference<ReadinessProfileRequestDTO>() {},
     object : ParameterizedTypeReference<List<ReadinessProfileDTO>>() {},
@@ -41,3 +40,5 @@ abstract class ReadinessProfileV1TestCase :
 
   protected fun parseProfile(profileData: JsonNode): Profile = objectMapper.treeToValue(profileData, typeRefProfile)
 }
+
+private const val READINESS_PROFILE_V1_ENDPOINT = "/v1/readiness-profiles"

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/integration/resource/v2/ReadinessProfileV2TestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/integration/resource/v2/ReadinessProfileV2TestCase.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.JsonNode
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.core.ParameterizedTypeReference
 import uk.gov.justice.digital.hmpps.educationemployment.api.integration.helpers.ProfileV1Helper
+import uk.gov.justice.digital.hmpps.educationemployment.api.integration.resource.READINESS_PROFILE_ENDPOINT
 import uk.gov.justice.digital.hmpps.educationemployment.api.integration.resource.ReadinessProfileTestCase
 import uk.gov.justice.digital.hmpps.educationemployment.api.profiledata.domain.ProfileStatus
 import uk.gov.justice.digital.hmpps.educationemployment.api.profiledata.domain.v2.Profile
@@ -22,7 +23,7 @@ import uk.gov.justice.digital.hmpps.educationemployment.api.readinessprofile.app
 
 abstract class ReadinessProfileV2TestCase :
   ReadinessProfileTestCase<ReadinessProfileDTO, ReadinessProfileRequestDTO>(
-    READINESS_PROFILE_V2_ENDPOINT,
+    READINESS_PROFILE_ENDPOINT,
     ReadinessProfileDTO::class.java,
     object : TypeReference<ReadinessProfileRequestDTO>() {},
     object : ParameterizedTypeReference<List<ReadinessProfileDTO>>() {},
@@ -64,5 +65,3 @@ abstract class ReadinessProfileV2TestCase :
     assertAddReadinessProfileIsOk(it.offenderId, it.requestDto).body
   }.filterNotNull()
 }
-
-private const val READINESS_PROFILE_V2_ENDPOINT = "/v2/readiness-profiles"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/resource/v1/ProfileResourceControllerV1.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/resource/v1/ProfileResourceControllerV1.kt
@@ -39,7 +39,7 @@ private const val API_V2_PATH = "/v2/readiness-profiles/{offenderId}"
 
 @Validated
 @RestController
-@RequestMapping("/readiness-profiles", "/v1/readiness-profiles", produces = [MediaType.APPLICATION_JSON_VALUE])
+@RequestMapping("/v1/readiness-profiles", produces = [MediaType.APPLICATION_JSON_VALUE])
 @Tag(name = API_VERSION)
 class ProfileResourceControllerV1(
   private val profileService: ProfileV1Service,
@@ -224,7 +224,6 @@ class ProfileResourceControllerV1(
 
   @PreAuthorize("hasAnyRole('WORK_READINESS_VIEW','WORK_READINESS_EDIT')")
   @GetMapping("/{offenderId}")
-  @Tag(name = "Popular")
   @Operation(
     summary = "Fetch the work readiness profile for a given offender",
     description = "Currently requires role $DESC_READ_ONLY_ROLES",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/resource/v2/ProfileResourceController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/resource/v2/ProfileResourceController.kt
@@ -32,7 +32,7 @@ const val API_VERSION = "v2"
 
 @Validated
 @RestController
-@RequestMapping("/v2/readiness-profiles", produces = [MediaType.APPLICATION_JSON_VALUE])
+@RequestMapping("/readiness-profiles", "/v2/readiness-profiles", produces = [MediaType.APPLICATION_JSON_VALUE])
 @Tag(name = API_VERSION)
 class ProfileResourceController(
   private val profileService: ProfileV2Service,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/resource/v1/ProfileResourceControllerV1Test.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/resource/v1/ProfileResourceControllerV1Test.kt
@@ -31,7 +31,7 @@ import uk.gov.justice.digital.hmpps.educationemployment.api.readinessprofile.dom
 import uk.gov.justice.digital.hmpps.educationemployment.api.resource.ControllerTestBase
 import kotlin.test.assertEquals
 
-private const val READINESS_PROFILES_PATH = "/readiness-profiles"
+private const val READINESS_PROFILES_PATH = "/v1/readiness-profiles"
 const val SEARCH_ENDPOINT = "$READINESS_PROFILES_PATH/search"
 const val PROFILE_ENDPOINT = "$READINESS_PROFILES_PATH/{id}"
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/resource/v2/ProfileResourceControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/resource/v2/ProfileResourceControllerTest.kt
@@ -26,7 +26,7 @@ import uk.gov.justice.digital.hmpps.educationemployment.api.readinessprofile.dom
 import uk.gov.justice.digital.hmpps.educationemployment.api.resource.ControllerTestBase
 import kotlin.test.assertEquals
 
-private const val READINESS_PROFILES_PATH = "/v2/readiness-profiles"
+private const val READINESS_PROFILES_PATH = "/readiness-profiles"
 const val SEARCH_ENDPOINT = "$READINESS_PROFILES_PATH/search"
 const val PROFILE_ENDPOINT = "$READINESS_PROFILES_PATH/{id}"
 


### PR DESCRIPTION
`/readiness-profiles` default to v2 APIs