### PR TITLE
ESWE-997 view work status progress

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/readinessprofile/application/v2/ProfileV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/readinessprofile/application/v2/ProfileV2Service.kt
@@ -110,6 +110,11 @@ class ProfileV2Service(
         updateProfileAcceptStatusChange(profile, userId, offenderId, profileToUpdate, currentTime)
     }
 
+    if (storedCoreProfile.status != profile.status) {
+      profile.statusChange = true
+      profile.statusChangeDate = currentTime
+    }
+
     with(profileToUpdate) {
       profile.within12Weeks ?: run { profile.within12Weeks = true }
       schemaVersion = PROFILE_SCHEMA_VERSION

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/profiledata/domain/ProfileTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/profiledata/domain/ProfileTest.kt
@@ -29,6 +29,7 @@ class ProfileTest {
 
     assertTrue(json.contains("\"status\":\"NO_RIGHT_TO_WORK\""))
     assertTrue(json.contains("\"statusChangeType\":\"NEW\""))
+    assertTrue(json.contains("\"statusChange\":true"))
     assertFalse(json.contains("statusAsList"))
     assertFalse(json.contains("statusChangeAsList"))
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/readinessprofile/application/v2/ProfileV2ServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/readinessprofile/application/v2/ProfileV2ServiceTest.kt
@@ -30,6 +30,7 @@ import uk.gov.justice.digital.hmpps.educationemployment.api.readinessprofile.dom
 import uk.gov.justice.digital.hmpps.educationemployment.api.shared.application.UnitTestBase
 import java.util.*
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
 
 @TestInstance(TestInstance.Lifecycle.PER_METHOD)
 class ProfileV2ServiceTest : UnitTestBase() {
@@ -184,49 +185,194 @@ class ProfileV2ServiceTest : UnitTestBase() {
     }
 
     @Nested
-    @DisplayName("And the readiness profile with decline is found")
+    @DisplayName("And the readiness profile with 'support declined' is found")
     inner class AndProfileWithDeclineIsFound {
       private val profileWithDecline = V2Profiles.readinessProfileAndDeclined1
 
       private val profileDataWithAcceptance = V2Profiles.profileAcceptedAndModified
-      private val profileWithAcceptance = V2Profiles.updatedReadinessProfileAndAccepted1
+      private val profileDataReadyToWork = V2Profiles.profileReadyToWorkAndModified
+      private val profileDataNoRightToWork = V2Profiles.profileNoRightToWorkAndModified
+      private val profileDataWithDecline = V2Profiles.profileDeclinedAndModified
 
       @BeforeEach
       internal fun setUp() {
-        givenProfileFound(profileWithDecline)
+        givenProfileFound(profileWithDecline.copy())
+        mockSaveProfile()
       }
 
       @Test
-      fun `set statusChangeType to DECLINED_TO_ACCEPTED, on Update of acceptedSupport in readiness profile`() {
-        givenSavedProfile(profileWithAcceptance)
+      fun `set statusChangeType to DECLINED_TO_ACCEPTED, on Update of 'support accepted' in readiness profile`() {
 
-        val actual = assertProfileIsUpdated(userId, prisonNumber, bookingId, profileDataWithAcceptance)
+        // Before update, expect StatusChangeType is NEW and statusChange is false
+        val profileBefore: ReadinessProfile = profileWithDecline
+        profileJsonToValue(profileBefore.profileData) . let {
+          assertThat(it.statusChangeType!!).isEqualTo(StatusChange.NEW)
+          assertThat(it.statusChange!!).isEqualTo(false)
+        }
 
-        profileJsonToValue(actual.profileData).let {
+        val profileAfter = assertProfileIsUpdated(userId, prisonNumber, bookingId, profileDataWithAcceptance)
+
+        // After update, expect StatusChangeType and statusChange to have been updated correctly.
+        profileJsonToValue(profileAfter.profileData).let {
           assertThat(it.statusChangeType!!).isEqualTo(StatusChange.DECLINED_TO_ACCEPTED)
+          assertThat(it.statusChange!!).isEqualTo(true)
+        }
+      }
+
+      @Test
+      fun `set statusChangeType to DECLINED_TO_ACCEPTED, on Update of 'ready to work' in readiness profile`() {
+
+        // Before update, expect StatusChangeType is NEW and statusChange is false
+        val profileBefore: ReadinessProfile = profileWithDecline
+        profileJsonToValue(profileBefore.profileData) . let {
+          assertThat(it.statusChangeType!!).isEqualTo(StatusChange.NEW)
+          assertThat(it.statusChange!!).isEqualTo(false)
+        }
+
+        val profileAfter = assertProfileIsUpdated(userId, prisonNumber, bookingId, profileDataReadyToWork)
+
+        // After update, expect StatusChangeType and statusChange to have been updated correctly.
+        profileJsonToValue(profileAfter.profileData).let {
+          assertThat(it.statusChangeType!!).isEqualTo(StatusChange.DECLINED_TO_ACCEPTED)
+          assertThat(it.statusChange!!).isEqualTo(true)
+        }
+      }
+
+      @Test
+      fun `set statusChangeType to NULL, on Update of 'no right to work' in readiness profile`() {
+
+        // Before update, expect StatusChangeType is NEW and statusChange is false
+        val profileBefore: ReadinessProfile = profileWithDecline
+        profileJsonToValue(profileBefore.profileData) . let {
+          assertThat(it.statusChangeType!!).isEqualTo(StatusChange.NEW)
+          assertThat(it.statusChange!!).isEqualTo(false)
+        }
+
+        val profileAfter = assertProfileIsUpdated(userId, prisonNumber, bookingId, profileDataNoRightToWork)
+
+        // After update, expect StatusChangeType and statusChange to have been updated correctly.
+        profileJsonToValue(profileAfter.profileData).let {
+          assertNull(it.statusChangeType)
+          assertThat(it.statusChange!!).isEqualTo(true)
+        }
+      }
+
+      @Test
+      fun `set statusChangeType to NULL, on no change from 'support declined' in readiness profile`() {
+
+        // Before update, expect StatusChangeType is NEW and statusChange is false
+        val profileBefore: ReadinessProfile = profileWithDecline
+        profileJsonToValue(profileBefore.profileData).let {
+          assertThat(it.statusChangeType!!).isEqualTo(StatusChange.NEW)
+          assertThat(it.statusChange!!).isEqualTo(false)
+        }
+
+        val profileAfter = assertProfileIsUpdated(userId, prisonNumber, bookingId, profileDataWithDecline)
+
+        // After update, expect StatusChangeType and statusChange to have been updated correctly.
+        profileJsonToValue(profileAfter.profileData).let {
+          assertNull(it.statusChangeType)
+          assertThat(it.statusChange!!).isEqualTo(false)
         }
       }
     }
 
     @Nested
-    @DisplayName("And the readiness profile with acceptance is found")
+    @DisplayName("And the readiness profile with 'support accepted' is found")
     inner class AndProfileWithAcceptanceIsFound {
       private val profileWithAcceptance = V2Profiles.readinessProfileAndAccepted1
-      private val profileDataWithAcceptance = V2Profiles.profileAcceptedAndModified
+      private val profileDataWithDecline = V2Profiles.profileDeclinedAndModified
 
       @BeforeEach
       internal fun setUp() {
         givenProfileFound(profileWithAcceptance)
+        mockSaveProfile()
       }
 
       @Test
       fun `set statusChangeType to ACCEPTED_TO_DECLINED, on Update of declinedSupport in readiness profile`() {
-        givenSavedProfile(updatedProfileWithDecline)
 
-        val actual = assertProfileIsUpdated(userId, prisonNumber, bookingId, profileDataWithAcceptance)
 
-        profileJsonToValue(actual.profileData).let {
-          assertThat(it.statusChangeType!!.equals(StatusChange.ACCEPTED_TO_DECLINED))
+        // Before update, expect StatusChangeType is NEW and statusChange is false
+        val profileBefore: ReadinessProfile = profileWithAcceptance
+        profileJsonToValue(profileBefore.profileData) . let {
+          assertThat(it.statusChangeType!!).isEqualTo(StatusChange.NEW)
+          assertThat(it.statusChange!!).isEqualTo(false)
+        }
+
+        val profileAfter = assertProfileIsUpdated(userId, prisonNumber, bookingId, profileDataWithDecline)
+
+        // After update, expect StatusChangeType and statusChange to have been updated correctly.
+        profileJsonToValue(profileAfter.profileData).let {
+          assertThat(it.statusChangeType!!).isEqualTo(StatusChange.ACCEPTED_TO_DECLINED)
+          assertThat(it.statusChange!!).isEqualTo(true)
+        }
+      }
+    }
+
+    @Nested
+    @DisplayName("And the readiness profile with 'no right to work' is found")
+    inner class AndProfileWithNoRightToWorkIsFound {
+      private val profileWithNoRightToWork = V2Profiles.readinessProfileAndNoRightToWork1
+
+      private val profileDataWithAcceptance = V2Profiles.profileAcceptedAndModified
+
+      @BeforeEach
+      internal fun setUp() {
+        givenProfileFound(profileWithNoRightToWork)
+        mockSaveProfile()
+      }
+
+      @Test
+      fun `set statusChangeType to DECLINED_TO_ACCEPTED, on Update of acceptedSupport in readiness profile`() {
+
+
+        // Before update, expect StatusChangeType is NEW and statusChange is false
+        val profileBefore: ReadinessProfile = profileWithNoRightToWork
+        profileJsonToValue(profileBefore.profileData) . let {
+          assertThat(it.statusChangeType!!).isEqualTo(StatusChange.NEW)
+          assertThat(it.statusChange!!).isEqualTo(false)
+        }
+
+        val profileAfter = assertProfileIsUpdated(userId, prisonNumber, bookingId, profileDataWithAcceptance)
+
+        // After update, expect StatusChangeType and statusChange to have been updated correctly.
+        profileJsonToValue(profileAfter.profileData).let {
+          assertThat(it.statusChangeType!!).isEqualTo(StatusChange.DECLINED_TO_ACCEPTED)
+          assertThat(it.statusChange!!).isEqualTo(true)
+        }
+      }
+    }
+
+    @Nested
+    @DisplayName("And the readiness profile with 'ready to work' is found")
+    inner class AndProfileWithReadyToWorkIsFound {
+      private val profileWithReadyToWork = V2Profiles.readinessProfileAndReadyToWork1
+      private val profileDataWithDecline = V2Profiles.profileDeclinedAndModified
+
+      @BeforeEach
+      internal fun setUp() {
+        givenProfileFound(profileWithReadyToWork)
+        mockSaveProfile()
+      }
+
+      @Test
+      fun `set statusChangeType to ACCEPTED_TO_DECLINED, on Update of declinedSupport in readiness profile`() {
+
+
+        // Before update, expect StatusChangeType is NEW and statusChange is false
+        val profileBefore: ReadinessProfile = profileWithReadyToWork
+        profileJsonToValue(profileBefore.profileData) . let {
+          assertThat(it.statusChangeType!!).isEqualTo(StatusChange.NEW)
+          assertThat(it.statusChange!!).isEqualTo(false)
+        }
+
+        val profileAfter = assertProfileIsUpdated(userId, prisonNumber, bookingId, profileDataWithDecline)
+
+        // After update, expect StatusChangeType and statusChange to have been updated correctly.
+        profileJsonToValue(profileAfter.profileData).let {
+          assertThat(it.statusChangeType!!).isEqualTo(StatusChange.ACCEPTED_TO_DECLINED)
+          assertThat(it.statusChange!!).isEqualTo(true)
         }
       }
     }
@@ -334,6 +480,10 @@ class ProfileV2ServiceTest : UnitTestBase() {
   private fun givenProfileExistence(prisonNumber: String, isExisting: Boolean) = whenever(readinessProfileRepository.existsById(prisonNumber)).thenReturn(isExisting)
 
   private fun givenSavedProfile(profile: ReadinessProfile) = whenever(readinessProfileRepository.save(any())).thenReturn(profile)
+
+  private fun mockSaveProfile() {
+    whenever(readinessProfileRepository.save(any())).thenAnswer { it.arguments[0] as ReadinessProfile }
+  }
 
   private fun givenProfileFound(profile: ReadinessProfile) = lenient().whenever(readinessProfileRepository.findById(any())).thenReturn(Optional.of(profile))
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/readinessprofile/application/v2/ProfileV2ServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/readinessprofile/application/v2/ProfileV2ServiceTest.kt
@@ -281,7 +281,6 @@ class ProfileV2ServiceTest : UnitTestBase() {
       private val profileDataReadyToWork = V2Profiles.profileReadyToWorkAndModified.copy()
       private val profileDataNoRightToWork = V2Profiles.profileNoRightToWorkAndModified.copy()
 
-
       @BeforeEach
       internal fun setUp() {
         givenProfileFound(profileWithAcceptance.copy())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/readinessprofile/application/v2/ProfileV2ServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/readinessprofile/application/v2/ProfileV2ServiceTest.kt
@@ -202,10 +202,9 @@ class ProfileV2ServiceTest : UnitTestBase() {
 
       @Test
       fun `set statusChangeType to DECLINED_TO_ACCEPTED, on Update of 'support accepted' in readiness profile`() {
-
         // Before update, expect StatusChangeType is NEW and statusChange is false
         val profileBefore: ReadinessProfile = profileWithDecline
-        profileJsonToValue(profileBefore.profileData) . let {
+        profileJsonToValue(profileBefore.profileData).let {
           assertThat(it.statusChangeType!!).isEqualTo(StatusChange.NEW)
           assertThat(it.statusChange!!).isEqualTo(false)
         }
@@ -221,10 +220,9 @@ class ProfileV2ServiceTest : UnitTestBase() {
 
       @Test
       fun `set statusChangeType to DECLINED_TO_ACCEPTED, on Update of 'ready to work' in readiness profile`() {
-
         // Before update, expect StatusChangeType is NEW and statusChange is false
         val profileBefore: ReadinessProfile = profileWithDecline
-        profileJsonToValue(profileBefore.profileData) . let {
+        profileJsonToValue(profileBefore.profileData).let {
           assertThat(it.statusChangeType!!).isEqualTo(StatusChange.NEW)
           assertThat(it.statusChange!!).isEqualTo(false)
         }
@@ -240,10 +238,9 @@ class ProfileV2ServiceTest : UnitTestBase() {
 
       @Test
       fun `set statusChangeType to NULL, on Update of 'no right to work' in readiness profile`() {
-
         // Before update, expect StatusChangeType is NEW and statusChange is false
         val profileBefore: ReadinessProfile = profileWithDecline
-        profileJsonToValue(profileBefore.profileData) . let {
+        profileJsonToValue(profileBefore.profileData).let {
           assertThat(it.statusChangeType!!).isEqualTo(StatusChange.NEW)
           assertThat(it.statusChange!!).isEqualTo(false)
         }
@@ -259,7 +256,6 @@ class ProfileV2ServiceTest : UnitTestBase() {
 
       @Test
       fun `set statusChangeType to NULL, on no change from 'support declined' in readiness profile`() {
-
         // Before update, expect StatusChangeType is NEW and statusChange is false
         val profileBefore: ReadinessProfile = profileWithDecline
         profileJsonToValue(profileBefore.profileData).let {
@@ -291,11 +287,9 @@ class ProfileV2ServiceTest : UnitTestBase() {
 
       @Test
       fun `set statusChangeType to ACCEPTED_TO_DECLINED, on Update of declinedSupport in readiness profile`() {
-
-
         // Before update, expect StatusChangeType is NEW and statusChange is false
         val profileBefore: ReadinessProfile = profileWithAcceptance
-        profileJsonToValue(profileBefore.profileData) . let {
+        profileJsonToValue(profileBefore.profileData).let {
           assertThat(it.statusChangeType!!).isEqualTo(StatusChange.NEW)
           assertThat(it.statusChange!!).isEqualTo(false)
         }
@@ -325,11 +319,9 @@ class ProfileV2ServiceTest : UnitTestBase() {
 
       @Test
       fun `set statusChangeType to DECLINED_TO_ACCEPTED, on Update of acceptedSupport in readiness profile`() {
-
-
         // Before update, expect StatusChangeType is NEW and statusChange is false
         val profileBefore: ReadinessProfile = profileWithNoRightToWork
-        profileJsonToValue(profileBefore.profileData) . let {
+        profileJsonToValue(profileBefore.profileData).let {
           assertThat(it.statusChangeType!!).isEqualTo(StatusChange.NEW)
           assertThat(it.statusChange!!).isEqualTo(false)
         }
@@ -358,11 +350,9 @@ class ProfileV2ServiceTest : UnitTestBase() {
 
       @Test
       fun `set statusChangeType to ACCEPTED_TO_DECLINED, on Update of declinedSupport in readiness profile`() {
-
-
         // Before update, expect StatusChangeType is NEW and statusChange is false
         val profileBefore: ReadinessProfile = profileWithReadyToWork
-        profileJsonToValue(profileBefore.profileData) . let {
+        profileJsonToValue(profileBefore.profileData).let {
           assertThat(it.statusChangeType!!).isEqualTo(StatusChange.NEW)
           assertThat(it.statusChange!!).isEqualTo(false)
         }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/readinessprofile/application/v2/ProfileV2ServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/readinessprofile/application/v2/ProfileV2ServiceTest.kt
@@ -188,7 +188,6 @@ class ProfileV2ServiceTest : UnitTestBase() {
     @DisplayName("And the readiness profile with 'support declined' is found")
     inner class AndProfileWithDeclineIsFound {
       private val profileWithDecline = V2Profiles.readinessProfileAndDeclined1
-
       private val profileDataWithAcceptance = V2Profiles.profileAcceptedAndModified.copy()
       private val profileDataReadyToWork = V2Profiles.profileReadyToWorkAndModified.copy()
       private val profileDataNoRightToWork = V2Profiles.profileNoRightToWorkAndModified.copy()
@@ -201,7 +200,7 @@ class ProfileV2ServiceTest : UnitTestBase() {
       }
 
       @Test
-      fun `set statusChangeType to DECLINED_TO_ACCEPTED, on Update of 'support accepted' in readiness profile`() {
+      fun `set statusChangeType to DECLINED_TO_ACCEPTED, on Update of 'support needed' in readiness profile`() {
         // Before update, expect StatusChangeType is NEW and statusChange is false
         val profileBefore: ReadinessProfile = profileWithDecline
         profileJsonToValue(profileBefore.profileData).let {
@@ -278,15 +277,19 @@ class ProfileV2ServiceTest : UnitTestBase() {
     inner class AndProfileWithAcceptanceIsFound {
       private val profileWithAcceptance = V2Profiles.readinessProfileAndAccepted1
       private val profileDataWithDecline = V2Profiles.profileDeclinedAndModified.copy()
+      private val profileDataWithAcceptance = V2Profiles.profileAcceptedAndModified.copy()
+      private val profileDataReadyToWork = V2Profiles.profileReadyToWorkAndModified.copy()
+      private val profileDataNoRightToWork = V2Profiles.profileNoRightToWorkAndModified.copy()
+
 
       @BeforeEach
       internal fun setUp() {
-        givenProfileFound(profileWithAcceptance)
+        givenProfileFound(profileWithAcceptance.copy())
         mockSaveProfile()
       }
 
       @Test
-      fun `set statusChangeType to ACCEPTED_TO_DECLINED, on Update of declinedSupport in readiness profile`() {
+      fun `set statusChangeType to ACCEPTED_TO_DECLINED, on Update of 'support declined' in readiness profile`() {
         // Before update, expect StatusChangeType is NEW and statusChange is false
         val profileBefore: ReadinessProfile = profileWithAcceptance
         profileJsonToValue(profileBefore.profileData).let {
@@ -302,23 +305,79 @@ class ProfileV2ServiceTest : UnitTestBase() {
           assertThat(it.statusChange!!).isEqualTo(true)
         }
       }
+
+      @Test
+      fun `set statusChangeType to NULL, on Update of 'ready to work' in readiness profile`() {
+        // Before update, expect StatusChangeType is NEW and statusChange is false
+        val profileBefore: ReadinessProfile = profileWithAcceptance
+        profileJsonToValue(profileBefore.profileData).let {
+          assertThat(it.statusChangeType!!).isEqualTo(StatusChange.NEW)
+          assertThat(it.statusChange!!).isEqualTo(false)
+        }
+
+        val profileAfter = assertProfileIsUpdated(userId, prisonNumber, bookingId, profileDataReadyToWork)
+
+        // After update, expect StatusChangeType and statusChange to have been updated correctly.
+        profileJsonToValue(profileAfter.profileData).let {
+          assertNull(it.statusChangeType)
+          assertThat(it.statusChange!!).isEqualTo(true)
+        }
+      }
+
+      @Test
+      fun `set statusChangeType to ACCEPTED_TO_DECLINED, on Update of 'no right to work' in readiness profile`() {
+        // Before update, expect StatusChangeType is NEW and statusChange is false
+        val profileBefore: ReadinessProfile = profileWithAcceptance
+        profileJsonToValue(profileBefore.profileData).let {
+          assertThat(it.statusChangeType!!).isEqualTo(StatusChange.NEW)
+          assertThat(it.statusChange!!).isEqualTo(false)
+        }
+
+        val profileAfter = assertProfileIsUpdated(userId, prisonNumber, bookingId, profileDataNoRightToWork)
+
+        // After update, expect StatusChangeType and statusChange to have been updated correctly.
+        profileJsonToValue(profileAfter.profileData).let {
+          assertThat(it.statusChangeType!!).isEqualTo(StatusChange.ACCEPTED_TO_DECLINED)
+          assertThat(it.statusChange!!).isEqualTo(true)
+        }
+      }
+
+      @Test
+      fun `set statusChangeType to NULL, on no change from 'support needed' in readiness profile`() {
+        // Before update, expect StatusChangeType is NEW and statusChange is false
+        val profileBefore: ReadinessProfile = profileWithAcceptance
+        profileJsonToValue(profileBefore.profileData).let {
+          assertThat(it.statusChangeType!!).isEqualTo(StatusChange.NEW)
+          assertThat(it.statusChange!!).isEqualTo(false)
+        }
+
+        val profileAfter = assertProfileIsUpdated(userId, prisonNumber, bookingId, profileDataWithAcceptance)
+
+        // After update, expect StatusChangeType and statusChange to have been updated correctly.
+        profileJsonToValue(profileAfter.profileData).let {
+          assertNull(it.statusChangeType)
+          assertThat(it.statusChange!!).isEqualTo(false)
+        }
+      }
     }
 
     @Nested
     @DisplayName("And the readiness profile with 'no right to work' is found")
     inner class AndProfileWithNoRightToWorkIsFound {
       private val profileWithNoRightToWork = V2Profiles.readinessProfileAndNoRightToWork1
-
-      private val profileDataWithAcceptance = V2Profiles.profileAcceptedAndModified
+      private val profileDataWithAcceptance = V2Profiles.profileAcceptedAndModified.copy()
+      private val profileDataWithDecline = V2Profiles.profileDeclinedAndModified.copy()
+      private val profileDataReadyToWork = V2Profiles.profileReadyToWorkAndModified.copy()
+      private val profileDataNoRightToWork = V2Profiles.profileNoRightToWorkAndModified.copy()
 
       @BeforeEach
       internal fun setUp() {
-        givenProfileFound(profileWithNoRightToWork)
+        givenProfileFound(profileWithNoRightToWork.copy())
         mockSaveProfile()
       }
 
       @Test
-      fun `set statusChangeType to DECLINED_TO_ACCEPTED, on Update of acceptedSupport in readiness profile`() {
+      fun `set statusChangeType to DECLINED_TO_ACCEPTED, on Update of 'support needed' in readiness profile`() {
         // Before update, expect StatusChangeType is NEW and statusChange is false
         val profileBefore: ReadinessProfile = profileWithNoRightToWork
         profileJsonToValue(profileBefore.profileData).let {
@@ -334,6 +393,60 @@ class ProfileV2ServiceTest : UnitTestBase() {
           assertThat(it.statusChange!!).isEqualTo(true)
         }
       }
+
+      @Test
+      fun `set statusChangeType to DECLINED_TO_ACCEPTED, on Update of 'ready to work' in readiness profile`() {
+        // Before update, expect StatusChangeType is NEW and statusChange is false
+        val profileBefore: ReadinessProfile = profileWithNoRightToWork
+        profileJsonToValue(profileBefore.profileData).let {
+          assertThat(it.statusChangeType!!).isEqualTo(StatusChange.NEW)
+          assertThat(it.statusChange!!).isEqualTo(false)
+        }
+
+        val profileAfter = assertProfileIsUpdated(userId, prisonNumber, bookingId, profileDataReadyToWork)
+
+        // After update, expect StatusChangeType and statusChange to have been updated correctly.
+        profileJsonToValue(profileAfter.profileData).let {
+          assertThat(it.statusChangeType!!).isEqualTo(StatusChange.DECLINED_TO_ACCEPTED)
+          assertThat(it.statusChange!!).isEqualTo(true)
+        }
+      }
+
+      @Test
+      fun `set statusChangeType to NULL, on Update of 'support declined' in readiness profile`() {
+        // Before update, expect StatusChangeType is NEW and statusChange is false
+        val profileBefore: ReadinessProfile = profileWithNoRightToWork
+        profileJsonToValue(profileBefore.profileData).let {
+          assertThat(it.statusChangeType!!).isEqualTo(StatusChange.NEW)
+          assertThat(it.statusChange!!).isEqualTo(false)
+        }
+
+        val profileAfter = assertProfileIsUpdated(userId, prisonNumber, bookingId, profileDataWithDecline)
+
+        // After update, expect StatusChangeType and statusChange to have been updated correctly.
+        profileJsonToValue(profileAfter.profileData).let {
+          assertNull(it.statusChangeType)
+          assertThat(it.statusChange!!).isEqualTo(true)
+        }
+      }
+
+      @Test
+      fun `set statusChangeType to NULL, on no change from 'no right to work' in readiness profile`() {
+        // Before update, expect StatusChangeType is NEW and statusChange is false
+        val profileBefore: ReadinessProfile = profileWithNoRightToWork
+        profileJsonToValue(profileBefore.profileData).let {
+          assertThat(it.statusChangeType!!).isEqualTo(StatusChange.NEW)
+          assertThat(it.statusChange!!).isEqualTo(false)
+        }
+
+        val profileAfter = assertProfileIsUpdated(userId, prisonNumber, bookingId, profileDataNoRightToWork)
+
+        // After update, expect StatusChangeType and statusChange to have been updated correctly.
+        profileJsonToValue(profileAfter.profileData).let {
+          assertNull(it.statusChangeType)
+          assertThat(it.statusChange!!).isEqualTo(false)
+        }
+      }
     }
 
     @Nested
@@ -341,15 +454,18 @@ class ProfileV2ServiceTest : UnitTestBase() {
     inner class AndProfileWithReadyToWorkIsFound {
       private val profileWithReadyToWork = V2Profiles.readinessProfileAndReadyToWork1
       private val profileDataWithDecline = V2Profiles.profileDeclinedAndModified.copy()
+      private val profileDataWithAcceptance = V2Profiles.profileAcceptedAndModified.copy()
+      private val profileDataReadyToWork = V2Profiles.profileReadyToWorkAndModified.copy()
+      private val profileDataNoRightToWork = V2Profiles.profileNoRightToWorkAndModified.copy()
 
       @BeforeEach
       internal fun setUp() {
-        givenProfileFound(profileWithReadyToWork)
+        givenProfileFound(profileWithReadyToWork.copy())
         mockSaveProfile()
       }
 
       @Test
-      fun `set statusChangeType to ACCEPTED_TO_DECLINED, on Update of declinedSupport in readiness profile`() {
+      fun `set statusChangeType to ACCEPTED_TO_DECLINED, on Update of 'support declined' in readiness profile`() {
         // Before update, expect StatusChangeType is NEW and statusChange is false
         val profileBefore: ReadinessProfile = profileWithReadyToWork
         profileJsonToValue(profileBefore.profileData).let {
@@ -363,6 +479,60 @@ class ProfileV2ServiceTest : UnitTestBase() {
         profileJsonToValue(profileAfter.profileData).let {
           assertThat(it.statusChangeType!!).isEqualTo(StatusChange.ACCEPTED_TO_DECLINED)
           assertThat(it.statusChange!!).isEqualTo(true)
+        }
+      }
+
+      @Test
+      fun `set statusChangeType to NULL, on Update of 'support needed' in readiness profile`() {
+        // Before update, expect StatusChangeType is NEW and statusChange is false
+        val profileBefore: ReadinessProfile = profileWithReadyToWork
+        profileJsonToValue(profileBefore.profileData).let {
+          assertThat(it.statusChangeType!!).isEqualTo(StatusChange.NEW)
+          assertThat(it.statusChange!!).isEqualTo(false)
+        }
+
+        val profileAfter = assertProfileIsUpdated(userId, prisonNumber, bookingId, profileDataWithAcceptance)
+
+        // After update, expect StatusChangeType and statusChange to have been updated correctly.
+        profileJsonToValue(profileAfter.profileData).let {
+          assertNull(it.statusChangeType)
+          assertThat(it.statusChange!!).isEqualTo(true)
+        }
+      }
+
+      @Test
+      fun `set statusChangeType to ACCEPTED_TO_DECLINED, on Update of 'no right to work' in readiness profile`() {
+        // Before update, expect StatusChangeType is NEW and statusChange is false
+        val profileBefore: ReadinessProfile = profileWithReadyToWork
+        profileJsonToValue(profileBefore.profileData).let {
+          assertThat(it.statusChangeType!!).isEqualTo(StatusChange.NEW)
+          assertThat(it.statusChange!!).isEqualTo(false)
+        }
+
+        val profileAfter = assertProfileIsUpdated(userId, prisonNumber, bookingId, profileDataNoRightToWork)
+
+        // After update, expect StatusChangeType and statusChange to have been updated correctly.
+        profileJsonToValue(profileAfter.profileData).let {
+          assertThat(it.statusChangeType!!).isEqualTo(StatusChange.ACCEPTED_TO_DECLINED)
+          assertThat(it.statusChange!!).isEqualTo(true)
+        }
+      }
+
+      @Test
+      fun `set statusChangeType to NULL, on no change from 'ready to work' in readiness profile`() {
+        // Before update, expect StatusChangeType is NEW and statusChange is false
+        val profileBefore: ReadinessProfile = profileWithReadyToWork
+        profileJsonToValue(profileBefore.profileData).let {
+          assertThat(it.statusChangeType!!).isEqualTo(StatusChange.NEW)
+          assertThat(it.statusChange!!).isEqualTo(false)
+        }
+
+        val profileAfter = assertProfileIsUpdated(userId, prisonNumber, bookingId, profileDataReadyToWork)
+
+        // After update, expect StatusChangeType and statusChange to have been updated correctly.
+        profileJsonToValue(profileAfter.profileData).let {
+          assertNull(it.statusChangeType)
+          assertThat(it.statusChange!!).isEqualTo(false)
         }
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/readinessprofile/application/v2/ProfileV2ServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/readinessprofile/application/v2/ProfileV2ServiceTest.kt
@@ -189,10 +189,10 @@ class ProfileV2ServiceTest : UnitTestBase() {
     inner class AndProfileWithDeclineIsFound {
       private val profileWithDecline = V2Profiles.readinessProfileAndDeclined1
 
-      private val profileDataWithAcceptance = V2Profiles.profileAcceptedAndModified
-      private val profileDataReadyToWork = V2Profiles.profileReadyToWorkAndModified
-      private val profileDataNoRightToWork = V2Profiles.profileNoRightToWorkAndModified
-      private val profileDataWithDecline = V2Profiles.profileDeclinedAndModified
+      private val profileDataWithAcceptance = V2Profiles.profileAcceptedAndModified.copy()
+      private val profileDataReadyToWork = V2Profiles.profileReadyToWorkAndModified.copy()
+      private val profileDataNoRightToWork = V2Profiles.profileNoRightToWorkAndModified.copy()
+      private val profileDataWithDecline = V2Profiles.profileDeclinedAndModified.copy()
 
       @BeforeEach
       internal fun setUp() {
@@ -277,7 +277,7 @@ class ProfileV2ServiceTest : UnitTestBase() {
     @DisplayName("And the readiness profile with 'support accepted' is found")
     inner class AndProfileWithAcceptanceIsFound {
       private val profileWithAcceptance = V2Profiles.readinessProfileAndAccepted1
-      private val profileDataWithDecline = V2Profiles.profileDeclinedAndModified
+      private val profileDataWithDecline = V2Profiles.profileDeclinedAndModified.copy()
 
       @BeforeEach
       internal fun setUp() {
@@ -340,7 +340,7 @@ class ProfileV2ServiceTest : UnitTestBase() {
     @DisplayName("And the readiness profile with 'ready to work' is found")
     inner class AndProfileWithReadyToWorkIsFound {
       private val profileWithReadyToWork = V2Profiles.readinessProfileAndReadyToWork1
-      private val profileDataWithDecline = V2Profiles.profileDeclinedAndModified
+      private val profileDataWithDecline = V2Profiles.profileDeclinedAndModified.copy()
 
       @BeforeEach
       internal fun setUp() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/readinessprofile/domain/ProfileObjects.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/readinessprofile/domain/ProfileObjects.kt
@@ -71,7 +71,9 @@ object ProfileObjects {
   val actionModified = Action(ActionTodo.CV_AND_COVERING_LETTER, ActionStatus.IN_PROGRESS, null, null)
 
   val profileStatusNoRightToWork = ProfileStatus.NO_RIGHT_TO_WORK
+  val profileStatusSupportDeclined = ProfileStatus.SUPPORT_DECLINED
   val profileStatusSupportNeeded = ProfileStatus.SUPPORT_NEEDED
+  val profileStatusReadyToWork = ProfileStatus.READY_TO_WORK
 
   val supportDeclinedReasonList = listOf(SupportToWorkDeclinedReason.FULL_TIME_CARER)
   val supportDeclinedReasonModifiedList = listOf(SupportToWorkDeclinedReason.HEALTH)
@@ -178,11 +180,16 @@ object ProfileObjects {
   // Latest V2 profiles
   object V2Profiles {
     val profile: Profile = makeProfile(
-      status = profileStatusNoRightToWork,
+      status = profileStatusSupportDeclined,
       supportDeclined = supportDeclined,
     )
 
     val profileDeclined = profile.copy()
+
+    val profileNoRightToWork: Profile = makeProfile(
+      status = profileStatusNoRightToWork,
+      supportDeclined = supportDeclined,
+    )
 
     val profileDeclinedModified = makeProfile(
       status = profileStatusNoRightToWork,
@@ -194,11 +201,33 @@ object ProfileObjects {
       supportAccepted = supportAccepted,
     )
 
+    val profileReadyToWork = makeProfile(
+      status = profileStatusReadyToWork,
+      supportAccepted = supportAccepted,
+    )
+
     val profileAcceptedAndModified = makeProfile(
       status = profileStatusSupportNeeded,
       supportAccepted = supportAcceptedModified,
-      supportDeclined = supportDeclined,
-      statusChangeType = StatusChange.DECLINED_TO_ACCEPTED,
+      statusChangeType = null,
+    )
+
+    val profileReadyToWorkAndModified = makeProfile(
+      status = profileStatusReadyToWork,
+      supportAccepted = supportAcceptedModified,
+      statusChangeType = null,
+    )
+
+    val profileDeclinedAndModified = makeProfile(
+      status = profileStatusSupportDeclined,
+      supportDeclined = supportDeclinedModified,
+      statusChangeType = null,
+    )
+
+    val profileNoRightToWorkAndModified = makeProfile(
+      status = profileStatusNoRightToWork,
+      supportDeclined = supportDeclinedModified,
+      statusChangeType = null,
     )
 
     val profileStatusNewAndBothStateIncorrect = makeProfile(
@@ -287,6 +316,19 @@ object ProfileObjects {
       true,
     )
 
+    val readinessProfileAndNoRightToWork1 = ReadinessProfile(
+      newOffenderId,
+      newBookingId,
+      createdBy,
+      createdTime,
+      createdBy,
+      modifiedTime,
+      "2.0",
+      objectMapper.valueToTree(profileNoRightToWork),
+      emptyJsonArray,
+      true,
+    )
+
     val readinessProfileAndAccepted1 = ReadinessProfile(
       newOffenderId,
       newBookingId,
@@ -296,6 +338,19 @@ object ProfileObjects {
       modifiedTime,
       "2.0",
       objectMapper.valueToTree(profileAccepted),
+      emptyJsonArray,
+      true,
+    )
+
+    val readinessProfileAndReadyToWork1 = ReadinessProfile(
+      newOffenderId,
+      newBookingId,
+      createdBy,
+      createdTime,
+      createdBy,
+      modifiedTime,
+      "2.0",
+      objectMapper.valueToTree(profileReadyToWork),
       emptyJsonArray,
       true,
     )
@@ -326,7 +381,7 @@ object ProfileObjects {
   object V1Profiles {
     // V1 profiles
     val profile = makeProfileV1(
-      status = profileStatusNoRightToWork,
+      status = profileStatusSupportDeclined,
       supportDeclined = supportDeclined,
       supportDeclined_history = mutableListOf(supportDeclined),
       supportAccepted_history = mutableListOf(supportAccepted),
@@ -344,6 +399,7 @@ object ProfileObjects {
       supportAccepted = supportAcceptedModified,
       supportDeclined = supportDeclined,
       statusChangeType = StatusChange.DECLINED_TO_ACCEPTED,
+      statusChange = true,
     )
 
     val profileDeclinedModified = makeProfileV1(


### PR DESCRIPTION
- Set 'statusChange' = 'true' when any status change occurs, not just when going from accepted -> declined or declined -> accepted. This will enable reporting the total number of prisoners who have changed status, regardless of the type of status change.
- Update UTs to verify status fields are being set correctly.