### PR TITLE
ESWE-1814: Fix Optional fields of API requests/responses (profile, SAR)

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/sardata/domain/SupportAccepted.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/sardata/domain/SupportAccepted.kt
@@ -2,23 +2,22 @@ package uk.gov.justice.digital.hmpps.educationemployment.api.sardata.domain
 
 import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.hmpps.educationemployment.api.profiledata.application.instantFromZone
-import uk.gov.justice.digital.hmpps.educationemployment.api.shared.application.ModificationAudited
 import java.time.Instant
 import java.time.ZoneId
 import uk.gov.justice.digital.hmpps.educationemployment.api.profiledata.domain.SupportAccepted as SupportAcceptedEntity
 
 @Schema(name = "SARSupportAccepted", description = "Support accepted of the SAR Readiness Profile")
 data class SupportAccepted(
-  override val modifiedBy: String,
-  override val modifiedDateTime: Instant,
+  val modifiedBy: String?,
+  val modifiedDateTime: Instant?,
   val actionsRequired: ActionsRequired,
   val workImpacts: WorkImpacts,
   val workInterests: WorkInterests,
   val workExperience: WorkExperience,
-) : ModificationAudited {
+) {
   constructor(entity: SupportAcceptedEntity, timeZoneId: ZoneId) : this(
-    modifiedBy = entity.modifiedBy!!,
-    modifiedDateTime = entity.modifiedDateTime!!.instantFromZone(timeZoneId),
+    modifiedBy = entity.modifiedBy,
+    modifiedDateTime = entity.modifiedDateTime?.instantFromZone(timeZoneId),
     actionsRequired = ActionsRequired(entity.actionsRequired, timeZoneId),
     workImpacts = WorkImpacts(entity.workImpacts, timeZoneId),
     workInterests = WorkInterests(entity.workInterests, timeZoneId),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/sardata/domain/SupportDeclined.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/sardata/domain/SupportDeclined.kt
@@ -10,8 +10,8 @@ import uk.gov.justice.digital.hmpps.educationemployment.api.profiledata.domain.S
 
 @Schema(name = "SARSupportDeclined", description = "Support declined of the SAR Readiness Profile")
 data class SupportDeclined(
-  val modifiedBy: String,
-  val modifiedDateTime: Instant,
+  val modifiedBy: String?,
+  val modifiedDateTime: Instant?,
 
   val supportToWorkDeclinedReason: List<SupportToWorkDeclinedReason>,
   val supportToWorkDeclinedReasonOther: String,
@@ -19,8 +19,8 @@ data class SupportDeclined(
   val circumstanceChangesRequiredToWorkOther: String,
 ) {
   constructor(entity: SupportDeclinedEntity, timeZoneId: ZoneId) : this(
-    modifiedBy = entity.modifiedBy!!,
-    modifiedDateTime = entity.modifiedDateTime!!.instantFromZone(timeZoneId),
+    modifiedBy = entity.modifiedBy,
+    modifiedDateTime = entity.modifiedDateTime?.instantFromZone(timeZoneId),
     supportToWorkDeclinedReason = entity.supportToWorkDeclinedReason.toList(),
     supportToWorkDeclinedReasonOther = entity.supportToWorkDeclinedReasonOther,
     circumstanceChangesRequiredToWork = entity.circumstanceChangesRequiredToWork.toList(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/shared/application/BaseDTOs.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/educationemployment/api/shared/application/BaseDTOs.kt
@@ -5,10 +5,10 @@ import java.time.Instant
 import java.time.ZoneId
 
 interface ModificationAuditable {
-  @get:Schema(description = "Author of modification", example = "user4", required = true)
+  @get:Schema(description = "Author of modification", example = "user4")
   var modifiedBy: String?
 
-  @get:Schema(description = "Modified date and time", type = "string", format = "date-time", pattern = "yyyy-MM-dd'T'HH:mm:ssZ", example = "2018-12-01T13:45:00Z", required = true)
+  @get:Schema(description = "Modified date and time", type = "string", format = "date-time", pattern = "yyyy-MM-dd'T'HH:mm:ssZ", example = "2018-12-01T13:45:00Z")
   var modifiedDateTime: Instant?
 }
 


### PR DESCRIPTION
Make `modifiedBy` and `modifiedDateTime` optional at `supportAccepted` of API requests (profile) and responses (profile and SAR).