### PR TITLE
ESWE-1880: Update dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,22 +1,22 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "10.1.2"
-  kotlin("plugin.spring") version "2.3.20"
-  kotlin("plugin.jpa") version "2.3.20"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "10.2.2"
+  kotlin("plugin.spring") version "2.3.21"
+  kotlin("plugin.jpa") version "2.3.21"
   id("jacoco")
 }
 
 dependencies {
-  implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter:2.1.0")
+  implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter:2.1.1")
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
   implementation("org.springframework.boot:spring-boot-starter-flyway")
   implementation("org.springframework.data:spring-data-envers")
-  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.2")
+  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.3")
   implementation("com.fasterxml.jackson.core:jackson-databind")
 
   runtimeOnly("org.flywaydb:flyway-database-postgresql")
   runtimeOnly("org.postgresql:postgresql")
 
-  testImplementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter-test:2.1.0")
+  testImplementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter-test:2.1.1")
   testImplementation("org.springframework.security:spring-security-test")
   testImplementation("org.springframework.boot:spring-boot-starter-webmvc-test")
   testImplementation("org.jetbrains.kotlin:kotlin-test")
@@ -35,8 +35,8 @@ testing {
     val integrationTest by registering(JvmTestSuite::class) {
       dependencies {
         kotlin.target.compilations { named("integrationTest") { associateWith(getByName("main")) } }
-        implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter-test:2.1.0")
-        implementation("uk.gov.justice.service.hmpps:hmpps-subject-access-request-test-support:2.1.3")
+        implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter-test:2.1.1")
+        implementation("uk.gov.justice.service.hmpps:hmpps-subject-access-request-test-support:2.3.0")
         implementation("org.springframework.boot:spring-boot-starter-test")
         implementation("org.springframework.boot:spring-boot-starter-data-jpa-test")
         implementation("org.springframework.boot:spring-boot-restclient")
@@ -47,7 +47,7 @@ testing {
         runtimeOnly("org.flywaydb:flyway-database-postgresql")
         implementation("org.testcontainers:testcontainers-postgresql")
         implementation("org.mockito.kotlin:mockito-kotlin:6.3.0")
-        implementation("io.swagger.parser.v3:swagger-parser:2.1.39") {
+        implementation("io.swagger.parser.v3:swagger-parser:2.1.40") {
           exclude(group = "io.swagger.core.v3")
         }
       }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -117,5 +117,3 @@ hmpps:
     template:
       path: /sar/template_hmpps-education-employment-api.mustache
       enabled: true
-
-springdoc.swagger-ui.version: 5.32.1


### PR DESCRIPTION
Update plugin/dependencies
- HMPPS Gradle Spring Boot plugin to `10.2.2`
- Kotlin to `2.3.21`
- Spring Boot to `4.0.6`
- HMPPS Kotlin lib to `2.1.1`
- SAR lib to `2.3.0`
- `swagger-parser` to `2.1.40`
- `springdoc-openapi-starter-webmvc-ui` to `3.0.3`
- Unpin Swagger UI